### PR TITLE
Document the default app timeouts

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -37,7 +37,7 @@ The following arguments are supported:
    * an empty blank string to use built-in buildpacks (i.e. autodetection)
 * `command` - (Optional, String) A custom start command for the application. This overrides the start command provided by the buildpack.
 * `enable_ssh` - (Optional, Boolean) Whether to enable or disable SSH access to the container. Default is `true` unless disabled globally.
-* `timeout` - (Optional, Number) Max wait time for app instance startup, in seconds
+* `timeout` - (Optional, Number) Max wait time for app instance startup, in seconds. Defaults to 60 seconds.
 * `stopped` - (Optional, Boolean) Defines the desired application state. Set to `true` to have the application remain in a stopped state. Default is `false`, i.e. application will be started.
 * `labels` - (Optional, map string of string) Add labels as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object). 
 Works only on cloud foundry with api >= v3.63.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -146,6 +146,12 @@ The following attributes are exported along with any defaults for the inputs att
 * `id_bg` - The GUID of the application updated by resource when strategy is blue-green. 
 This allow change a resource linked to app resource id to be updated when app will be recreated.
 
+## Timeouts
+
+* App instance startup timeout - see the `timeout` argument.
+* App staging timeout - 15 mins.
+* Service binding timeout - 5 mins.
+
 ## Import
 
 The current App can be imported using the `app` GUID, e.g.


### PR DESCRIPTION
Hi! This PR updates the documentation to mention the default and hardcoded timeouts that apply to the `cloudfoundry_app` resource. One of our users was surprised to see a push fail when they hadn't configured any timeouts; this PR should stop people being surprised like that again.