### PR TITLE
Improve route create reliability

### DIFF
--- a/cloudfoundry/resource_cf_route.go
+++ b/cloudfoundry/resource_cf_route.go
@@ -3,7 +3,8 @@ package cloudfoundry
 import (
 	"fmt"
 	"net/http"
-	"time"
+
+	"github.com/cenkalti/backoff/v4"
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
@@ -104,28 +105,28 @@ func resourceRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		port.Value = v.(int)
 		port.IsSet = true
 	}
-	operation := func() (ccv2.Route, error) {
-		route, _, err := session.ClientV2.CreateRoute(ccv2.Route{
+	var route ccv2.Route
+
+	operation := func() error {
+		var err error
+		route, _, err = session.ClientV2.CreateRoute(ccv2.Route{
 			DomainGUID: d.Get("domain").(string),
 			SpaceGUID:  d.Get("space").(string),
 			Host:       d.Get("hostname").(string),
 			Path:       d.Get("path").(string),
 			Port:       port,
 		}, d.Get("random_port").(bool))
-		return route, err
-	}
-	route, err := operation()
-	if err != nil {
-		if unexpected, ok := err.(ccerror.V2UnexpectedResponseError); ok && unexpected.ResponseCode == http.StatusInternalServerError {
-			// Retry one more time
-			time.Sleep(1 * time.Second)
-			route, err = operation()
-			if err != nil {
+		if err != nil {
+			if unexpected, ok := err.(ccerror.V2UnexpectedResponseError); ok && unexpected.ResponseCode == http.StatusInternalServerError {
 				return err
 			}
-		} else {
-			return err
+			return backoff.Permanent(err)
 		}
+		return nil
+	}
+	err := backoff.Retry(operation, backoff.NewExponentialBackOff())
+	if err != nil {
+		return err
 	}
 	// Delete route if an error occurs
 	defer func() {

--- a/cloudfoundry/resource_cf_route.go
+++ b/cloudfoundry/resource_cf_route.go
@@ -2,7 +2,10 @@ package cloudfoundry
 
 import (
 	"fmt"
+	"net/http"
+	"time"
 
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 	"code.cloudfoundry.org/cli/types"
@@ -101,16 +104,28 @@ func resourceRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		port.Value = v.(int)
 		port.IsSet = true
 	}
-
-	route, _, err := session.ClientV2.CreateRoute(ccv2.Route{
-		DomainGUID: d.Get("domain").(string),
-		SpaceGUID:  d.Get("space").(string),
-		Host:       d.Get("hostname").(string),
-		Path:       d.Get("path").(string),
-		Port:       port,
-	}, d.Get("random_port").(bool))
+	operation := func() (ccv2.Route, error) {
+		route, _, err := session.ClientV2.CreateRoute(ccv2.Route{
+			DomainGUID: d.Get("domain").(string),
+			SpaceGUID:  d.Get("space").(string),
+			Host:       d.Get("hostname").(string),
+			Path:       d.Get("path").(string),
+			Port:       port,
+		}, d.Get("random_port").(bool))
+		return route, err
+	}
+	route, err := operation()
 	if err != nil {
-		return err
+		if unexpected, ok := err.(ccerror.V2UnexpectedResponseError); ok && unexpected.ResponseCode == http.StatusInternalServerError {
+			// Retry one more time
+			time.Sleep(1 * time.Second)
+			route, err = operation()
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 	// Delete route if an error occurs
 	defer func() {

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bmatcuk/doublestar v1.2.2 // indirect
 	github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 // indirect
+	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 // indirect
 	github.com/cloudfoundry/bosh-cli v5.5.0+incompatible // indirect
 	github.com/cloudfoundry/bosh-utils v0.0.0-20190518100210-9f9df32d41c3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/bmatcuk/doublestar v1.2.2 h1:oC24CykoSAB8zd7XgruHo33E0cHJf/WhQA/7BeXj
 github.com/bmatcuk/doublestar v1.2.2/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 h1:y4B3+GPxKlrigF1ha5FFErxK+sr6sWxQovRMzwMhejo=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 h1:vTlpHKxJqykyKdW9bkrDJNWeKNuSIAJ0TP/K4lRsz/Q=
 github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1/go.mod h1:sAoA1zHCH4FJPE2gne5iBiiVG66U7Nyp6JqlOo+FEyg=


### PR DESCRIPTION
Th PR implements a retry mechanism which is triggered on on `HTTP 500` response for `POST /v2/route` requests. A few of our larger Terraform modules are triggering this error in Cloud foundry. The issue is triggered when 5-10 route create requests are posted in a short order. By adding this retry mechanism we have eliminated all failures.