### PR TITLE
Always restart app on environment changes. Fixes #294

### DIFF
--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -582,7 +582,8 @@ func IsAppRestageNeeded(d ResourceChanger) bool {
 func IsAppRestartNeeded(d ResourceChanger) bool {
 	return d.HasChange("memory") || d.HasChange("disk_quota") ||
 		d.HasChange("command") || d.HasChange("health_check_http_endpoint") ||
-		d.HasChange("docker_image") || d.HasChange("health_check_type") || d.HasChange("environment")
+		d.HasChange("docker_image") || d.HasChange("health_check_type") ||
+		d.HasChange("environment")
 }
 
 func isDiffAppParamsBinding(oldBinding, currentBinding map[string]interface{}) (bool, error) {

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -582,7 +582,7 @@ func IsAppRestageNeeded(d ResourceChanger) bool {
 func IsAppRestartNeeded(d ResourceChanger) bool {
 	return d.HasChange("memory") || d.HasChange("disk_quota") ||
 		d.HasChange("command") || d.HasChange("health_check_http_endpoint") ||
-		d.HasChange("docker_image") || d.HasChange("health_check_type")
+		d.HasChange("docker_image") || d.HasChange("health_check_type") || d.HasChange("environment")
 }
 
 func isDiffAppParamsBinding(oldBinding, currentBinding map[string]interface{}) (bool, error) {


### PR DESCRIPTION
When only the `environment` of a Docker app changes the provider does not restart the app so changes are not picked up. This PR adds an extra check to trigger restart under this condition.