### PR TITLE
Controlling the service instances binding in an ordered way

### DIFF
--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -132,12 +132,8 @@ func resourceApp() *schema.Resource {
 				ConflictsWith: []string{"path"},
 			},
 			"service_binding": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
-				Set: func(v interface{}) int {
-					elem := v.(map[string]interface{})
-					return hashcode.String(elem["service_instance"].(string))
-				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"service_instance": &schema.Schema{


### PR DESCRIPTION
As it is explained in this [raised issue ](https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/issues/290), we would like to control the service instances bindings.
After this change, things are working properly.