### PR TITLE
Let be possible to set role for org and space by username

### DIFF
--- a/cloudfoundry/resource_cf_org.go
+++ b/cloudfoundry/resource_cf_org.go
@@ -2,6 +2,8 @@ package cloudfoundry
 
 import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
+	"github.com/hashicorp/go-uuid"
 	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/managers"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -146,8 +148,13 @@ func resourceOrgUpdate(d *schema.ResourceData, meta interface{}) (err error) {
 				return err
 			}
 		}
-		for _, uid := range add {
-			_, err = om.UpdateOrganizationUserByRole(r, id, uid)
+		for _, uidOrUsername := range add {
+			byUsername := true
+			_, err := uuid.ParseUUID(uidOrUsername)
+			if err == nil {
+				byUsername = false
+			}
+			err = updateOrgUserByRole(session, r, id, uidOrUsername, byUsername)
 			if err != nil {
 				return err
 			}
@@ -158,6 +165,27 @@ func resourceOrgUpdate(d *schema.ResourceData, meta interface{}) (err error) {
 		return err
 	}
 	return nil
+}
+
+func updateOrgUserByRole(session *managers.Session, role constant.UserRole, guid string, guidOrUsername string, byUsername bool) error {
+	if !byUsername {
+		_, err := session.ClientV2.UpdateOrganizationUserByRole(role, guid, guidOrUsername)
+		if err != nil {
+			return err
+		}
+	}
+	var err error
+	switch role {
+	case constant.OrgAuditor:
+		_, err = session.ClientV2.UpdateOrganizationAuditorByUsername(guid, guidOrUsername)
+	case constant.OrgManager:
+		_, err = session.ClientV2.UpdateOrganizationManagerByUsername(guid, guidOrUsername)
+	case constant.BillingManager:
+		_, err = session.ClientV2.UpdateOrganizationBillingManagerByUsername(guid, guidOrUsername)
+	default:
+		_, err = session.ClientV2.UpdateOrganizationUserByUsername(guid, guidOrUsername)
+	}
+	return err
 }
 
 func resourceOrgDelete(d *schema.ResourceData, meta interface{}) (err error) {

--- a/docs/resources/org_users.md
+++ b/docs/resources/org_users.md
@@ -2,16 +2,17 @@
 layout: "cloudfoundry"
 page_title: "Cloud Foundry: cloudfoundry_org_users"
 sidebar_current: "docs-cf-resource-org-users"
-description: |-
-  Provides a Cloud Foundry Org users resource.
+description: |- Provides a Cloud Foundry Org users resource.
 ---
 
 # cloudfoundry\_org\_users
 
-Provides a Cloud Foundry resource for managing Cloud Foundry [organizations](https://docs.cloudfoundry.org/concepts/roles.html) members. 
+Provides a Cloud Foundry resource for managing Cloud
+Foundry [organizations](https://docs.cloudfoundry.org/concepts/roles.html) members.
 
 ~> **NOTE:** This resource requires the provider to be authenticated with an account granted admin permissions.
-~> **NOTE:** Only modify users managed in the resource, and ignore any existing other users provisioned elsewhere if not using `force` attribute.
+~> **NOTE:** Only modify users managed in the resource, and ignore any existing other users provisioned elsewhere if not
+using `force` attribute.
 
 ## Example Usage
 
@@ -19,10 +20,10 @@ The following example creates an org with a specific org-wide quota.
 
 ```hcl
 resource "cloudfoundry_org_users" "ou1" {
-    org              = "organization-id"
-    managers         = ["user-guid"]
-    billing_managers = ["user-guid"]
-    auditors         = ["user-guid"]
+  org              = "organization-id"
+  managers         = ["user-guid", "username"]
+  billing_managers = ["user-guid", "username"]
+  auditors         = ["user-guid", "username"]
 }
 ```
 
@@ -31,10 +32,18 @@ resource "cloudfoundry_org_users" "ou1" {
 The following arguments are supported:
 
 * `org` - (Required) Organization associated guid.
-* `managers` - (Optional) List of users to assign [OrgManager](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to. By default, no managers are assigned.
-* `billing_managers` - (Optional) List of ID of users to assign [BillingManager](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to.  By default, no billing managers are assigned.
-* `auditors` - (Optional) List of ID of users to assign [OrgAuditor](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to.  By default, no auditors are assigned.
-* `force` - (Optional, Boolean) Set to true to enforce that users defined here will be only theses users defined (remove users roles from external modification).
+* `managers` - (Optional) List of users to assign [OrgManager](https://docs.cloudfoundry.org/concepts/roles.html#roles)
+  role to. By default, no managers are assigned.
+* `billing_managers` - (Optional) List of ID of users to
+  assign [BillingManager](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to. By default, no billing
+  managers are assigned.
+* `auditors` - (Optional) List of ID of users to
+  assign [OrgAuditor](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to. By default, no auditors are
+  assigned.
+* `force` - (Optional, Boolean) Set to true to enforce that users defined here will be only theses users defined (remove
+  users roles from external modification).
+
+~> **NOTE:** User can be either an uua guid or a username as cloud foundry treat them both as valid identifier
 
 ## Import
 

--- a/docs/resources/space_users.md
+++ b/docs/resources/space_users.md
@@ -2,16 +2,18 @@
 layout: "cloudfoundry"
 page_title: "Cloud Foundry: cloudfoundry_space_users"
 sidebar_current: "docs-cf-resource-space-users"
-description: |-
-  Provides a Cloud Foundry Space users resource.
+description: |- Provides a Cloud Foundry Space users resource.
 ---
 
 # cloudfoundry\_space\_users
 
-Provides a Cloud Foundry resource for managing Cloud Foundry [space](https://docs.cloudfoundry.org/concepts/roles.html) members. 
+Provides a Cloud Foundry resource for managing Cloud Foundry [space](https://docs.cloudfoundry.org/concepts/roles.html)
+members.
 
-~> **NOTE:** This resource requires the provider to be authenticated with an account granted at least with `OrgManager` permission.
-~> **NOTE:** Only modify users managed in the resource, and ignore any existing other users provisioned elsewhere if not using `force` attribute.
+~> **NOTE:** This resource requires the provider to be authenticated with an account granted at least with `OrgManager`
+permission.
+~> **NOTE:** Only modify users managed in the resource, and ignore any existing other users provisioned elsewhere if not
+using `force` attribute.
 
 ## Example Usage
 
@@ -19,19 +21,22 @@ The following example creates an org with a specific org-wide quota.
 
 ```hcl
 resource "cloudfoundry_space_users" "su1" {
-    space    = "space-id"
-    managers = [
-        data.cloudfoundry_user.tl.id
-    ]
-    developers = [
-        data.cloudfoundry_user.tl.id,
-        data.cloudfoundry_user.dev1.id,
-        data.cloudfoundry_user.dev2.id
-    ]
-    auditors = [
-        data.cloudfoundry_user.adr.id,
-        data.cloudfoundry_user.dev3.id
-    ]
+  space      = "space-id"
+  managers   = [
+    data.cloudfoundry_user.tl.id,
+    "username",
+  ]
+  developers = [
+    data.cloudfoundry_user.tl.id,
+    data.cloudfoundry_user.dev1.id,
+    data.cloudfoundry_user.dev2.id,
+    "username",
+  ]
+  auditors   = [
+    data.cloudfoundry_user.adr.id,
+    data.cloudfoundry_user.dev3.id,
+    "username"
+  ]
 }
 ```
 
@@ -40,10 +45,16 @@ resource "cloudfoundry_space_users" "su1" {
 The following arguments are supported:
 
 * `space` - (Required) Space associated guid.
-* `managers` - (Optional) List of users to assign [SpaceManager](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to. Defaults to empty list.
-* `developers` - (Optional) List of users to assign [SpaceDeveloper](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to. Defaults to empty list.
-* `auditors` - (Optional) List of users to assign [SpaceAuditor](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to. Defaults to empty list.
-* `force` - (Optional, Boolean) Set to true to enforce that users defined here will be only theses users defined (remove users roles from external modification).
+* `managers` - (Optional) List of users to
+  assign [SpaceManager](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to. Defaults to empty list.
+* `developers` - (Optional) List of users to
+  assign [SpaceDeveloper](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to. Defaults to empty list.
+* `auditors` - (Optional) List of users to
+  assign [SpaceAuditor](https://docs.cloudfoundry.org/concepts/roles.html#roles) role to. Defaults to empty list.
+* `force` - (Optional, Boolean) Set to true to enforce that users defined here will be only theses users defined (remove
+  users roles from external modification).
+
+~> **NOTE:** User can be either an uua guid or a username as cloud foundry treat them both as valid identifier
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-cloudfoundry
 
 go 1.14
 
-replace code.cloudfoundry.org/cli => github.com/cloudfoundry-community/cloudfoundry-cli v0.0.6-complete-api
+replace code.cloudfoundry.org/cli => github.com/cloudfoundry-community/cloudfoundry-cli v0.0.7-complete-api
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20180906201452-2aa6f33b730c // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXH
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudfoundry-community/cloudfoundry-cli v0.0.6-complete-api h1:WxZyz7bfC6ELsuujckRv8YE3ur0Chq5zjKPfBKplr14=
 github.com/cloudfoundry-community/cloudfoundry-cli v0.0.6-complete-api/go.mod h1:DigEBZwaNy/7RSrQpKuMeADXY5tFaWaieQX+UM8+0fA=
+github.com/cloudfoundry-community/cloudfoundry-cli v0.0.7-complete-api h1:77JjuvP8yjU/csZ8ir44iwM0spIR4ODz/MvhSwKlzOQ=
+github.com/cloudfoundry-community/cloudfoundry-cli v0.0.7-complete-api/go.mod h1:DigEBZwaNy/7RSrQpKuMeADXY5tFaWaieQX+UM8+0fA=
 github.com/cloudfoundry/bosh-cli v5.5.0+incompatible h1:P+hlG8D9xXIi75yqTpFrNBHR3oMWWMPNhj5AwSN2tOU=
 github.com/cloudfoundry/bosh-cli v5.5.0+incompatible/go.mod h1:rzIB+e1sn7wQL/TJ54bl/FemPKRhXby5BIMS3tLuWFM=
 github.com/cloudfoundry/bosh-utils v0.0.0-20190518100210-9f9df32d41c3 h1:SbXvMoOwvn5r/uOx3ylQ5pDQxWPaV9dPW5kQ5VpfmUQ=


### PR DESCRIPTION
The cloud foundry cli allow to set space and org role by username. This is actually a valid configuration when you are org manager and space manager as you can't list users in uaa but know the username.

this PR let set roles by username (simply by putting username in tf file), example:

```hcl
resource "cloudfoundry_org_users" "ou1" {
  org              = "organization-id"
  managers         = ["a-username"]
}
```

Change are not that heavy as cloud foundry will treat username as guid when user are set.