### PR TITLE
Service bindings are created in order

### DIFF
--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -133,12 +133,8 @@ func resourceApp() *schema.Resource {
 				ConflictsWith: []string{"path"},
 			},
 			"service_binding": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
-				Set: func(v interface{}) int {
-					elem := v.(map[string]interface{})
-					return hashcode.String(elem["service_instance"].(string))
-				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"service_instance": &schema.Schema{

--- a/cloudfoundry/utils_terraform.go
+++ b/cloudfoundry/utils_terraform.go
@@ -19,6 +19,9 @@ func getListOfStructs(v interface{}) []map[string]interface{} {
 	}
 	vvv := []map[string]interface{}{}
 	for _, vv := range v.([]interface{}) {
+		if vv == nil {
+			continue
+		}
 		vvv = append(vvv, vv.(map[string]interface{}))
 	}
 	return vvv


### PR DESCRIPTION
This PR will fix #290 and come to replace PR #296
@foudelsalhi your PR was correct for > 0.12, sadly I still need to support 0.11 terraform. On 0.11 there was an panic error when converting.

0.12 this fix is totally transparent, below ths will recreate the app to reset bind which is acceptable.

Thanks for the work @foudelsalhi you will get credit on it.