### PR TITLE
Import default and global asg filter

### DIFF
--- a/cloudfoundry/resource_cf_space.go
+++ b/cloudfoundry/resource_cf_space.go
@@ -169,7 +169,10 @@ func resourceSpaceRead(d *schema.ResourceData, meta interface{}) error {
 		})
 		d.Set("asgs", schema.NewSet(resourceStringHash, finalRunningAsg))
 	} else {
-		d.Set("asgs", schema.NewSet(resourceStringHash, objectsToIds(runningAsgs, func(object interface{}) string {
+		finalRunningAsgs, _ := getInSlice(runningAsgs, func(object interface{}) bool {
+			return !object.(ccv2.SecurityGroup).RunningDefault
+		})
+		d.Set("asgs", schema.NewSet(resourceStringHash, objectsToIds(finalRunningAsgs, func(object interface{}) string {
 			return object.(ccv2.SecurityGroup).GUID
 		})))
 	}
@@ -184,7 +187,10 @@ func resourceSpaceRead(d *schema.ResourceData, meta interface{}) error {
 		})
 		d.Set("staging_asgs", schema.NewSet(resourceStringHash, finalStagingAsg))
 	} else {
-		d.Set("staging_asgs", schema.NewSet(resourceStringHash, objectsToIds(stagingAsgs, func(object interface{}) string {
+		finalStagingAsgs, _ := getInSlice(stagingAsgs, func(object interface{}) bool {
+			return !object.(ccv2.SecurityGroup).StagingDefault
+		})
+		d.Set("staging_asgs", schema.NewSet(resourceStringHash, objectsToIds(finalStagingAsgs, func(object interface{}) string {
 			return object.(ccv2.SecurityGroup).GUID
 		})))
 	}

--- a/cloudfoundry/resource_cf_space_users.go
+++ b/cloudfoundry/resource_cf_space_users.go
@@ -139,7 +139,13 @@ func resourceSpaceUsersUpdate(d *schema.ResourceData, meta interface{}) error {
 	for t, r := range typeToSpaceRoleMap {
 		remove, add := getListChanges(d.GetChange(t))
 		for _, uid := range remove {
-			_, err = session.ClientV2.DeleteSpaceUserByRole(r, spaceId, uid)
+			byUsername := true
+			_, err = uuid.ParseUUID(uid)
+			if err == nil {
+				byUsername = false
+			}
+
+			err = deleteSpaceUserByRole(session, r, spaceId, uid, byUsername)
 			if err != nil {
 				return err
 			}

--- a/cloudfoundry/resource_cf_space_users.go
+++ b/cloudfoundry/resource_cf_space_users.go
@@ -97,6 +97,7 @@ func resourceSpaceUsersCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceSpaceUsersRead(d *schema.ResourceData, meta interface{}) error {
 	if IsImportState(d) {
 		d.Set("space", d.Id())
+		d.Set("force", false)
 	}
 	session := meta.(*managers.Session)
 	for t, r := range typeToSpaceRoleMap {


### PR DESCRIPTION
This PR address 3 parts for idempotency : 
* Set `force` attribute to default value `false` when importing resource `cloudfoundry_space_users`
* Filter global security groups when importing resource `cloudfoundry_space`
* allow detection of `username` (vs `userid`) when reading resource `cloudfoundry_space_users` 