### PR TITLE
Turn on dependabot to get automated dependency bumps PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot does not seem turned on for this repo, only security upgrades seem currently received.

![image](https://user-images.githubusercontent.com/4748380/106740828-35eff300-661b-11eb-97cf-109be46f65d1.png)

Would regular dependabot PRs help maintaining dependency bumps such as terraform SDK 2.2.0 bump (see [related announcement](https://www.hashicorp.com/blog/making-terraform-provider-development-more-accessible)) ?

I believe this would need to be merged into default branch `master` to take effect.

More background at https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically and https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates