### PR TITLE
Allow diff customization for changed `docker_image` and `path`

### DIFF
--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -237,7 +237,6 @@ func resourceApp() *schema.Resource {
 				if oldPath == "" && newPath != "" && newImg == "" {
 					return diff.ForceNew("path")
 				}
-				return nil
 			}
 			if diff.Id() == "" {
 				return nil


### PR DESCRIPTION
Fixes cloudfoundry-community/terraform-provider-cloudfoundry#311

When `docker_image` or `path` parameters of a `cloudfoundry_app` are changed from a non-empty value, customization rules should not be ignored.
For example, for a `docker_image` being updated in the context of a blue/green deployment, it is required for the `id_bg` property to be flagged as being re-computed to reflect the change of GUID which will be caused by the deployment.