### PR TITLE
Increase service instance timeouts to 20 minutes

### DIFF
--- a/cloudfoundry/resource_cf_service_instance.go
+++ b/cloudfoundry/resource_cf_service_instance.go
@@ -29,9 +29,9 @@ func resourceServiceInstance() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(15 * time.Minute),
-			Update: schema.DefaultTimeout(15 * time.Minute),
-			Delete: schema.DefaultTimeout(15 * time.Minute),
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/docs/resources/service_instance.md
+++ b/docs/resources/service_instance.md
@@ -53,6 +53,6 @@ $ terraform import cloudfoundry_service.redis a-guid
 
 ## Timeouts
 
-* `create` - Default: 15 mins. Terraform will return an error if the resource was not deployed in the given timeframe.
-* `delete` - Default: 15 mins. Terraform will return an error if the resource was not deleted in the given timeframe.
-* `update` - Default: 15 mins. Terraform will return an error if the resource was not dupdated in the given timeframe.
+* `create` - Default: 20 mins. Terraform will return an error if the resource was not deployed in the given timeframe.
+* `delete` - Default: 20 mins. Terraform will return an error if the resource was not deleted in the given timeframe.
+* `update` - Default: 20 mins. Terraform will return an error if the resource was not dupdated in the given timeframe.


### PR DESCRIPTION
[Broker an AWS EKS instance](https://github.com/GSA/eks-brokerpak) takes longer than 15 minutes, so the Terraform provider assumes that provisioning has failed, even though provisioning continues and succeeds a few minutes later. 

In lieu of making this parameter configurable (I'm not very familiar with Go), I'm offering this PR increasing the timeout as the simplest possible way to solve my problem and move on. (I can also look at making this value configurable, but that's beyond my meager Go skills today.)

Also updates the documentation.