### PR TITLE
Feature: conditional replacement of service instances

### DIFF
--- a/cloudfoundry/resource_cf_service_instance.go
+++ b/cloudfoundry/resource_cf_service_instance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
@@ -35,7 +36,6 @@ func resourceServiceInstance() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -55,6 +55,16 @@ func resourceServiceInstance() *schema.Resource {
 				Default:      "",
 				ValidateFunc: validation.StringIsJSON,
 			},
+			"replace_on_service_plan_change": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"replace_on_params_change": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"tags": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -66,6 +76,23 @@ func resourceServiceInstance() *schema.Resource {
 				Default:  false,
 			},
 		},
+		CustomizeDiff: customdiff.All(
+			customdiff.ForceNewIf(
+				"service_plan", func(d *schema.ResourceDiff, meta interface{}) bool {
+					if ok := d.Get("replace_on_service_plan_change").(bool); ok {
+						return true
+					}
+					return false
+				}),
+			customdiff.ForceNewIf(
+				"params", func(d *schema.ResourceDiff, meta interface{}) bool {
+					if ok := d.Get("replace_on_params_change").(bool); ok {
+						return true
+					}
+					return false
+				},
+			),
+		),
 	}
 }
 

--- a/docs/resources/service_instance.md
+++ b/docs/resources/service_instance.md
@@ -36,6 +36,8 @@ The following arguments are supported:
 * `json_params` - (Optional, String) Json string of arbitrary parameters. Some services support providing additional configuration parameters within the provision request. By default, no params are provided.
 * `tags` - (Optional, List) List of instance tags. Some services provide a list of tags that Cloud Foundry delivers in [VCAP_SERVICES Env variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES). By default, no tags are assigned.
 * `recursive_delete` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will delete any service bindings, service keys, and route mappings associated with the service instance. This flag should only be set when such dependent resources were provisioned outside of terraform, and need removal to enable deletion of the associated service instance.
+* `replace_on_params_change` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will replace the resource on any params change. This is useful if the service does support parameter updates.
+* `replace_on_service_plan_change` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will replace the resource on any service plan changes. Some brokered services do not support plan changes and this allows the provider to handle those cases.
 
 ## Attributes Reference
 

--- a/docs/resources/service_instance.md
+++ b/docs/resources/service_instance.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `json_params` - (Optional, String) Json string of arbitrary parameters. Some services support providing additional configuration parameters within the provision request. By default, no params are provided.
 * `tags` - (Optional, List) List of instance tags. Some services provide a list of tags that Cloud Foundry delivers in [VCAP_SERVICES Env variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES). By default, no tags are assigned.
 * `recursive_delete` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will delete any service bindings, service keys, and route mappings associated with the service instance. This flag should only be set when such dependent resources were provisioned outside of terraform, and need removal to enable deletion of the associated service instance.
-* `replace_on_params_change` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will replace the resource on any params change. This is useful if the service does support parameter updates.
+* `replace_on_params_change` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will replace the resource on any params change. This is useful if the service does not support parameter updates.
 * `replace_on_service_plan_change` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will replace the resource on any service plan changes. Some brokered services do not support plan changes and this allows the provider to handle those cases.
 
 ## Attributes Reference


### PR DESCRIPTION
We frequently define modules which include provisioning of services. The service plans and parameters are typically configurable through module variables. Many of the brokered services we use (RDS, RabbitMQ, etc) do not provide `service plan` or `parameter` updates. This means that changing any of these variables on day 2 is effectively not possible and results in apply errors. By introducing the following 2 optional arguments to the `cloudfoundry_service_instance` practitioners get finer control over the behaviour of the service instance resource:

* `replace_on_params_change` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will replace the resource on any params change. This is useful if the underlying service does not support parameter updates.
* `replace_on_service_plan_change` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will replace the resource on any service plan changes. Some brokered services do not support plan changes and this allows the provider to handle those cases.

Since these values have defaults which do not alter previous behaviour in any way the change is fully backwards compatible.