### PR TITLE
Workaround when fail catalog when not accessible stuck state

### DIFF
--- a/cloudfoundry/data_source_cf_service.go
+++ b/cloudfoundry/data_source_cf_service.go
@@ -72,7 +72,7 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta int
 		for _, svc := range services {
 			brk, _, err := session.ClientV2.GetServiceBroker(svc.ServiceBrokerGUID)
 			if err != nil {
-				return err
+				return diag.FromErr(err)
 			}
 			if brk.SpaceGUID == space {
 				service = svc

--- a/cloudfoundry/managers/config.go
+++ b/cloudfoundry/managers/config.go
@@ -2,17 +2,18 @@ package managers
 
 // Config -
 type Config struct {
-	Endpoint          string
-	User              string
-	Password          string
-	SSOPasscode       string
-	CFClientID        string
-	CFClientSecret    string
-	UaaClientID       string
-	UaaClientSecret   string
-	SkipSslValidation bool
-	AppLogsMax        int
-	PurgeWhenDelete   bool
-	DefaultQuotaName  string
-	StoreTokensPath   string
+	Endpoint                  string
+	User                      string
+	Password                  string
+	SSOPasscode               string
+	CFClientID                string
+	CFClientSecret            string
+	UaaClientID               string
+	UaaClientSecret           string
+	SkipSslValidation         bool
+	AppLogsMax                int
+	PurgeWhenDelete           bool
+	DefaultQuotaName          string
+	StoreTokensPath           string
+	ForceNotFailBrokerCatalog bool
 }

--- a/cloudfoundry/provider.go
+++ b/cloudfoundry/provider.go
@@ -81,6 +81,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("CF_STORE_TOKENS_PATH", ""),
 				Description: "Path to a file to store tokens used for login. (this is useful for sso, this avoid requiring each time sso passcode)",
 			},
+			"force_broker_not_fail_when_catalog_not_accessible": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CF_FORCE_BROKER_NOT_FAIL_CATALOG", false),
+				Description: "Set to true to not trigger fail on catalog on service broker",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -137,18 +143,19 @@ func Provider() *schema.Provider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	c := managers.Config{
-		Endpoint:          strings.TrimSuffix(d.Get("api_url").(string), "/"),
-		User:              d.Get("user").(string),
-		Password:          d.Get("password").(string),
-		SSOPasscode:       d.Get("sso_passcode").(string),
-		CFClientID:        d.Get("cf_client_id").(string),
-		CFClientSecret:    d.Get("cf_client_secret").(string),
-		UaaClientID:       d.Get("uaa_client_id").(string),
-		UaaClientSecret:   d.Get("uaa_client_secret").(string),
-		SkipSslValidation: d.Get("skip_ssl_validation").(bool),
-		AppLogsMax:        d.Get("app_logs_max").(int),
-		DefaultQuotaName:  d.Get("default_quota_name").(string),
-		StoreTokensPath:   d.Get("store_tokens_path").(string),
+		Endpoint:                  strings.TrimSuffix(d.Get("api_url").(string), "/"),
+		User:                      d.Get("user").(string),
+		Password:                  d.Get("password").(string),
+		SSOPasscode:               d.Get("sso_passcode").(string),
+		CFClientID:                d.Get("cf_client_id").(string),
+		CFClientSecret:            d.Get("cf_client_secret").(string),
+		UaaClientID:               d.Get("uaa_client_id").(string),
+		UaaClientSecret:           d.Get("uaa_client_secret").(string),
+		SkipSslValidation:         d.Get("skip_ssl_validation").(bool),
+		AppLogsMax:                d.Get("app_logs_max").(int),
+		DefaultQuotaName:          d.Get("default_quota_name").(string),
+		StoreTokensPath:           d.Get("store_tokens_path").(string),
+		ForceNotFailBrokerCatalog: d.Get("force_broker_not_fail_when_catalog_not_accessible").(bool),
 	}
 	return managers.NewSession(c)
 }

--- a/cloudfoundry/resource_cf_service_broker.go
+++ b/cloudfoundry/resource_cf_service_broker.go
@@ -237,12 +237,19 @@ func readServiceDetail(id string, session *managers.Session, d *schema.ResourceD
 }
 
 func serviceBrokerUpdateCatalogSignature(d *schema.ResourceData, meta interface{}) error {
+	session := meta.(*managers.Session)
+
 	signature, err := serviceBrokerCatalogSignature(d, meta)
 	failNotAccessible := d.Get("fail_when_catalog_not_accessible").(bool)
 	if d.HasChange("fail_when_catalog_not_accessible") {
 		_, newFailNotAccessible := d.GetChange("fail_when_catalog_not_accessible")
 		failNotAccessible = newFailNotAccessible.(bool)
 	}
+
+	if session.Config.ForceNotFailBrokerCatalog {
+		failNotAccessible = false
+	}
+
 	if err != nil && failNotAccessible {
 		return fmt.Errorf("Error when getting catalog signature: %s", err.Error())
 	}

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,3 +79,6 @@ The following arguments are supported:
 
 * `store_tokens_path` - (Optional) Path to a file to store tokens used for login. (this is useful for sso, this avoid
   requiring each time sso passcode) . This can also be specified with the `CF_STORE_TOKENS_PATH` shell environment variable.
+  
+* `force_broker_not_fail_when_catalog_not_accessible` (Optional) Set to true to enforce `fail_when_catalog_not_accessible` to `true` to all broker for avoiding to be 
+  stuck if broker has been deleted for example. This can also be specified with the `CF_FORCE_BROKER_NOT_FAIL_CATALOG` shell environment variable.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-cloudfoundry
 
 go 1.15
 
-replace code.cloudfoundry.org/cli => github.com/cloudfoundry-community/cloudfoundry-cli v0.0.10-complete-api
+replace code.cloudfoundry.org/cli => github.com/cloudfoundry-community/cloudfoundry-cli v0.0.11-complete-api
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20180906201452-2aa6f33b730c // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudfoundry-community/cloudfoundry-cli v0.0.10-complete-api h1:NEtw6Erz9BscsXtjFdbTkM1G0o4n1TJ9cX0YOuvcoUI=
-github.com/cloudfoundry-community/cloudfoundry-cli v0.0.10-complete-api/go.mod h1:DigEBZwaNy/7RSrQpKuMeADXY5tFaWaieQX+UM8+0fA=
+github.com/cloudfoundry-community/cloudfoundry-cli v0.0.11-complete-api h1:sHemfIna3JE2pRw/jbZ7KCNyX4Boxw6Z1eFjY2z1T7A=
+github.com/cloudfoundry-community/cloudfoundry-cli v0.0.11-complete-api/go.mod h1:DigEBZwaNy/7RSrQpKuMeADXY5tFaWaieQX+UM8+0fA=
 github.com/cloudfoundry/bosh-cli v5.5.0+incompatible h1:P+hlG8D9xXIi75yqTpFrNBHR3oMWWMPNhj5AwSN2tOU=
 github.com/cloudfoundry/bosh-cli v5.5.0+incompatible/go.mod h1:rzIB+e1sn7wQL/TJ54bl/FemPKRhXby5BIMS3tLuWFM=
 github.com/cloudfoundry/bosh-utils v0.0.0-20190518100210-9f9df32d41c3 h1:SbXvMoOwvn5r/uOx3ylQ5pDQxWPaV9dPW5kQ5VpfmUQ=


### PR DESCRIPTION
Context is in issue #329 

This add to provider configuration a new variable called `force_broker_not_fail_when_catalog_not_accessible` associated to env var `CF_FORCE_BROKER_NOT_FAIL_CATALOG` when this variable is set to `true` it enforces `fail_when_catalog_not_accessible` to be `false` and every broker.

Example of usage:

1. create a broker:
```hcl
provider "cloudfoundry" {
# creds
}

resource "cloudfoundry_service_broker" "bookstore" {
  name                             = "bookstore"
  url                                  = "https://bookstore-service-broker.domain.net"
  username                      = "admin"
  password                       = "supersecret"
  fail_when_catalog_not_accessible = false
}
```
2. run `terraform apply` to create broker
3. Make your broker unaccessible
4. When running `terraform apply` you are now stuck due to fail
5. Simply now run command `CF_FORCE_BROKER_NOT_FAIL_CATALOG=true terraform apply` and this will not check for catalog and unstuck you


