### PR TITLE
Update typo from json_params to params_json in service_key documentation

### DIFF
--- a/docs/resources/service_key.md
+++ b/docs/resources/service_key.md
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the Service Key in Cloud Foundry.
 * `service_instance` - (Required) The ID of the Service Instance the key should be associated with.
 * `params` - (Optional, Map) A list of key/value parameters used by the service broker to create the binding for the key. By default, no parameters are provided.
-* `json_params` - (Optional, String) Arbitrary parameters in the form of stringified JSON object to pass to the service bind handler.
+* `params_json` - (Optional, String) Arbitrary parameters in the form of stringified JSON object to pass to the service bind handler.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The documentation incorrectly refers to the additional arguments parameter as json_params, but it should be params_json according to the codebase for [service_key ](https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/blob/master/cloudfoundry/resource_cf_service_key.go#L42)resource. (see issue #330).

This proposes to fix the typo in the document to avoid confusion for users.