### PR TITLE
Fixed typo in cloudfoundry_domain datasource docs - sub_domain attribute

### DIFF
--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -24,8 +24,8 @@ data "cloudfoundry_domain" "l" {
 
 The following arguments are supported and will be used to perform the lookup:
 
-* `name` - (Optional) This value will be computed based on the `sub-domain` or `domain` attributes. If provided then this argument will be used as the full domain name.
-* `sub-domain` - (Optional) The sub-domain of the full domain name
+* `name` - (Optional) This value will be computed based on the `sub_domain` or `domain` attributes. If provided then this argument will be used as the full domain name.
+* `sub_domain` - (Optional) The sub-domain of the full domain name
 * `domain` - (Optional) The domain name
 
 ## Attributes Reference


### PR DESCRIPTION
I see that `sub_domain` is valid attribute and not `sub-domain`. Corrected it.

I did read [contributing guidelines](https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/blob/05c4e8469b120f8715f5565eb59f48f421377e53/CONTRIBUTING.md) but not sure if I should merge this to `main` branch or `dev`. Please correct me as this is my first time here. 