### PR TITLE
CF Service Key credentials should be sensitive

### DIFF
--- a/cloudfoundry/data_source_cf_service_key.go
+++ b/cloudfoundry/data_source_cf_service_key.go
@@ -26,8 +26,9 @@ func dataSourceServiceKey() *schema.Resource {
 				Required: true,
 			},
 			"credentials": &schema.Schema{
-				Type:     schema.TypeMap,
-				Computed: true,
+				Type:      schema.TypeMap,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
Ran into a scenario where I needed to dump these to CI and noticed that the values were readily available.