### PR TITLE
Fix: BlueGreen - Ensure apps are stopped before destroying them 

### DIFF
--- a/cloudfoundry/managers/appdeployers/bluegreenv2_strategy.go
+++ b/cloudfoundry/managers/appdeployers/bluegreenv2_strategy.go
@@ -112,15 +112,12 @@ func (s BlueGreenV2) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 			Forward: func(ctx Context) (Context, error) {
 				// Ask CF to stop application (desired state)
 				_, _, err := s.clientV3.UpdateApplicationStop(appDeploy.App.GUID)
-				log.Print("Asked application to stop")
-				// time.Sleep(45 * time.Second)
 				return ctx, err
 			},
 		},
 		{
 			Forward: func(ctx Context) (Context, error) {
 				// Ensure application is stopped before continuing (timeout 10 sec)
-				log.Print("Ensuring application is stopped before continuing...")
 				channelIsStopped := make(chan bool, 1)
 				channelError := make(chan error, 1)
 				var err error
@@ -137,7 +134,6 @@ func (s BlueGreenV2) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 
 				select {
 				case <-channelIsStopped:
-					log.Print("Application and attached processes successfully stopped")
 				case <-time.After(stopAppTimeout * time.Second):
 					log.Print("Timeout of 10 seconds reach to stop application. Cloud Foundry sent SIGKILL to ensure application is down")
 				case <-channelError:

--- a/cloudfoundry/managers/appdeployers/bluegreenv2_strategy.go
+++ b/cloudfoundry/managers/appdeployers/bluegreenv2_strategy.go
@@ -136,7 +136,7 @@ func (s BlueGreenV2) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 				case <-channelIsStopped:
 				case <-time.After(stopAppTimeout * time.Second):
 					// App is not in expected state (stopped) after waiting for the timeout
-					log.Print("Timeout of reached while waiting for application to stop.")
+					log.Print("Timeout reached while waiting for application to stop.")
 				case <-channelError:
 					return ctx, err
 				}

--- a/cloudfoundry/managers/appdeployers/bluegreenv2_strategy.go
+++ b/cloudfoundry/managers/appdeployers/bluegreenv2_strategy.go
@@ -38,7 +38,7 @@ type metadata struct {
 
 const (
 	appMetadata          metadataType  = "apps"
-	stopAppTimeout       time.Duration = 15
+	stopAppTimeout       time.Duration = 15 // CF SHOULD send a SIGKILL if an app is not stopped after 10 seconds
 	delayBetweenRequests time.Duration = 1
 )
 
@@ -136,7 +136,7 @@ func (s BlueGreenV2) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 				case <-channelIsStopped:
 				case <-time.After(stopAppTimeout * time.Second):
 					// App is not in expected state (stopped) after waiting for the timeout
-					log.Print("Timeout reached while waiting for application to stop. Cloud Foundry sent SIGKILL to ensure application is down")
+					log.Print("Timeout of reached while waiting for application to stop.")
 				case <-channelError:
 					return ctx, err
 				}

--- a/cloudfoundry/managers/appdeployers/bluegreenv2_strategy.go
+++ b/cloudfoundry/managers/appdeployers/bluegreenv2_strategy.go
@@ -4,10 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
+	"time"
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+	constantV3 "code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/managers/bits"
 	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/managers/raw"
 )
@@ -15,6 +19,7 @@ import (
 type BlueGreenV2 struct {
 	bitsManager *bits.BitsManager
 	client      *ccv2.Client
+	clientV3    *ccv3.Client
 	rawClient   *raw.RawClient
 	runBinder   *RunBinder
 	standard    *Standard
@@ -32,13 +37,16 @@ type metadata struct {
 }
 
 const (
-	appMetadata metadataType = "apps"
+	appMetadata          metadataType  = "apps"
+	stopAppTimeout       time.Duration = 10
+	delayBetweenRequests time.Duration = 1
 )
 
-func NewBlueGreenV2(bitsManager *bits.BitsManager, client *ccv2.Client, rawClient *raw.RawClient, runBinder *RunBinder, standard *Standard) *BlueGreenV2 {
+func NewBlueGreenV2(bitsManager *bits.BitsManager, client *ccv2.Client, clientV3 *ccv3.Client, rawClient *raw.RawClient, runBinder *RunBinder, standard *Standard) *BlueGreenV2 {
 	return &BlueGreenV2{
 		bitsManager: bitsManager,
 		client:      client,
+		clientV3:    clientV3,
 		rawClient:   rawClient,
 		runBinder:   runBinder,
 		standard:    standard,
@@ -98,6 +106,46 @@ func (s BlueGreenV2) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 					_ = metadataUpdate(appResp.App.GUID, appMetadata, s.rawClient, metadata)
 				}
 				return ctx, nil
+			},
+		},
+		{
+			Forward: func(ctx Context) (Context, error) {
+				// Ask CF to stop application (desired state)
+				_, _, err := s.clientV3.UpdateApplicationStop(appDeploy.App.GUID)
+				log.Print("Asked application to stop")
+				// time.Sleep(45 * time.Second)
+				return ctx, err
+			},
+		},
+		{
+			Forward: func(ctx Context) (Context, error) {
+				// Ensure application is stopped before continuing (timeout 10 sec)
+				log.Print("Ensuring application is stopped before continuing...")
+				channelIsStopped := make(chan bool, 1)
+				channelError := make(chan error, 1)
+				var err error
+
+				go func() {
+					isStopped := false
+					for !isStopped {
+						isStopped, err = isAppStopped(s.clientV3, appDeploy.App.GUID)
+						time.Sleep(delayBetweenRequests * time.Second)
+					}
+					channelIsStopped <- isStopped
+					channelError <- err
+				}()
+
+				select {
+				case <-channelIsStopped:
+					log.Print("Application and attached processes successfully stopped")
+				case <-time.After(stopAppTimeout * time.Second):
+					log.Print("Timeout of 10 seconds reach to stop application. Cloud Foundry sent SIGKILL to ensure application is down")
+				case <-channelError:
+					log.Printf("An error occured when asking for application state. Waiting %d seconds to ensure Cloud Foundry sends a SIGKILL to shutdown the application", int64(stopAppTimeout))
+					time.Sleep(stopAppTimeout * time.Second)
+				}
+
+				return ctx, err
 			},
 		},
 		{
@@ -316,4 +364,28 @@ func metadataRetrieve(appGuid string, t metadataType, client *raw.RawClient) (me
 
 func pathMetadata(t metadataType, appGuid string) string {
 	return fmt.Sprintf("/v3/%s/%s", t, appGuid)
+}
+
+// Check the app subprocesses state to ensure it is really down.
+// Note: when you ask CF to stop an app, it tries to stop it gracefully, but after a timeout of 10 sec, it sends a SIGKILL
+func isAppStopped(clientV3 *ccv3.Client, appGUID string) (bool, error) {
+	isStopped := true
+	processes, _, err := clientV3.GetApplicationProcesses(appGUID)
+
+	if err == nil {
+		for _, process := range processes {
+			processInstances, _, err := clientV3.GetProcessInstances(process.GUID)
+			if err == nil {
+				for _, processInstance := range processInstances {
+					if processInstance.State != constantV3.ProcessInstanceDown {
+						isStopped = false
+					}
+				}
+			} else {
+				break
+			}
+		}
+	}
+
+	return isStopped, err
 }

--- a/cloudfoundry/managers/session.go
+++ b/cloudfoundry/managers/session.go
@@ -390,7 +390,7 @@ func (s *Session) init(config *configv3.Config, configUaa *configv3.Config, conf
 func (s *Session) loadDeployer() {
 	s.RunBinder = appdeployers.NewRunBinder(s.ClientV2, s.NOAAClient)
 	stdStrategy := appdeployers.NewStandard(s.BitsManager, s.ClientV2, s.RunBinder)
-	bgStrategy := appdeployers.NewBlueGreenV2(s.BitsManager, s.ClientV2, s.RawClient, s.RunBinder, stdStrategy)
+	bgStrategy := appdeployers.NewBlueGreenV2(s.BitsManager, s.ClientV2, s.ClientV3, s.RawClient, s.RunBinder, stdStrategy)
 	s.Deployer = appdeployers.NewDeployer(stdStrategy, bgStrategy)
 }
 


### PR DESCRIPTION
# Issue description
BlueGreen V2 destroys apps **imediately** after the new updated one handles the load, in order to be the fastest possible.

The problem is that some service bindings are destroyed **before** the app process itself, which makes the app generating tons of error for a few seconds (particularly for credentials issues).

This is related to this issue #353.

# Proposed fix
The fix I propose **stops** the application **before**  actually destroying it. This ensure the app shutdown as gracefully as possible without generating errors due to missing services.

There are 2 steps in this process:
1. The first one is asking CF to stop the app, which is fairly easy. I just use an API call to a specific route that will do it for us.
2. The second is the most complicated because we need to ensure it is actually stopped. Indeed, when you ask CF to stop an app, you actually ask for a **desired** state. Hence, it's not sure it's really stopped and you need to do some further API calls to know it:
   1. Ask for application processes lists
   2. For each processes, get the list of process instances
   3. For each process instances, get their state and see if it's set to `DOWN`
   4. Repeat previous steps for 10 seconds if the app is not stopped yet. This is because when you ask CF to stop an app, if the app doesn't stop by itself for the next 10 seconds, it will send a SIGKILL signal to imediately stop it.

I am using API V3 to achieve this, so I imported it and the V3 client to the `bluegreenV2_strategy.go`

Please don't hesitate to ask me any question or suggest any improvments.
I'm new to Golang and might have not followed every standards.
Since this is a fix, I thought submitting it to master was a better choice (also, dev seems too much behind master for this file)

_DISCLAIMER: Working on behalf of SAP_