### PR TITLE
Redeploy if docker image change

### DIFF
--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -637,7 +637,7 @@ func resourceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 }
 
 func IsAppCodeChange(d ResourceChanger) bool {
-	return d.HasChange("path") || d.HasChange("source_code_hash")
+	return d.HasChange("path") || d.HasChange("source_code_hash") || d.HasChange("docker_image")
 }
 
 func IsAppUpdateOnly(d ResourceChanger) bool {
@@ -655,8 +655,7 @@ func IsAppRestageNeeded(d ResourceChanger) bool {
 
 func IsAppRestartNeeded(d ResourceChanger) bool {
 	return d.HasChange("memory") || d.HasChange("disk_quota") ||
-		d.HasChange("command") || d.HasChange("health_check_http_endpoint") ||
-		d.HasChange("docker_image") || d.HasChange("health_check_type") ||
+		d.HasChange("command") || d.HasChange("health_check_http_endpoint") || d.HasChange("health_check_type") ||
 		d.HasChange("environment")
 }
 


### PR DESCRIPTION
In v2, the app update flow was 

- update docker_image field with PUT /v2/apps/guid
- restart the app (which automatically stages the new package)

This is no longer the case with the v3 API as changing docker image requires creation of a new package, staging of said new package and in case of rolling deployment, create a new deployment. 