### PR TITLE
Consume process update in cloudcontroller

### DIFF
--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -64,17 +64,17 @@ func resourceApp() *schema.Resource {
 			"instances": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  1,
+				Computed: true,
 			},
 			"memory": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  1024,
+				Computed: true,
 			},
 			"disk_quota": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  1024,
+				Computed: true,
 			},
 			"stack": &schema.Schema{
 				Type:     schema.TypeString,

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -135,7 +135,7 @@ resource "cloudfoundry_app" "java-spring" {
 ### Health Checks
 
 * `health_check_http_endpoint` -(Optional, String) The endpoint for the http health check type. The default is '/'.
-* `health_check_type` - (Optional, String) The health check type which can be one of "`port`", "`process`", "`http`" or "`none`". Default is "`port`".
+* `health_check_type` - (Optional, String) The health check type which can be one of "`port`", "`process`", "`http`". Default is "`port`".
 * `health_check_timeout` - (Optional, Number) The timeout in seconds for the health check.
 
 ## Attributes Reference


### PR DESCRIPTION
PR try to resolve issue #427 and #430 
- processUpdate now gets properly consumed in cloudcontroller when updating apps
- Update doc for health_check_type, remove previously valid value "none"
- Remove default values for instances, memory and disk_quota 