### PR TITLE
Move Data Sources Service Instance and UPS to CF API V3

### DIFF
--- a/cloudfoundry/data_source_cf_user_provided_service.go
+++ b/cloudfoundry/data_source_cf_user_provided_service.go
@@ -66,6 +66,10 @@ func dataSourceUserProvidedServiceRead(ctx context.Context, d *schema.ResourceDa
 
 	serviceInstance = serviceInstanceV3
 	credentials, _, err = session.ClientV3.GetUserProvidedServiceInstanceCredentails(serviceInstanceV3.GUID)
+	
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	d.SetId(serviceInstance.GUID)
 	d.Set("name", serviceInstance.Name)

--- a/cloudfoundry/data_source_cf_user_provided_service.go
+++ b/cloudfoundry/data_source_cf_user_provided_service.go
@@ -66,7 +66,7 @@ func dataSourceUserProvidedServiceRead(ctx context.Context, d *schema.ResourceDa
 
 	serviceInstance = serviceInstanceV3
 	credentials, _, err = session.ClientV3.GetUserProvidedServiceInstanceCredentails(serviceInstanceV3.GUID)
-	
+
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Hi,

in the course of migration to CF API V3 (https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/pull/417) data sources for service instance and UPS were out of scope. This PR brings them into the scope.

