### PR TITLE
Fix bugs for v3_appdeployer

### DIFF
--- a/cloudfoundry/managers/session.go
+++ b/cloudfoundry/managers/session.go
@@ -14,7 +14,6 @@ import (
 	"code.cloudfoundry.org/cfnetworking-cli-api/cfnetworking/cfnetv1"
 	netWrapper "code.cloudfoundry.org/cfnetworking-cli-api/cfnetworking/wrapper"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
-	ccv2cons "code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 	ccWrapper "code.cloudfoundry.org/cli/api/cloudcontroller/wrapper"
 	"code.cloudfoundry.org/cli/api/router"
@@ -417,7 +416,14 @@ func (s *Session) loadDeployer() {
 }
 
 func (s *Session) loadDefaultQuotaGuid(quotaName string) error {
-	quotas, _, err := s.ClientV2.GetQuotas(ccv2cons.OrgQuota, ccv2.FilterByName(quotaName))
+	// quotas, _, err := s.ClientV2.GetQuotas(ccv2cons.OrgQuota, ccv2.FilterByName(quotaName))
+	// if err != nil {
+	// 	return err
+	// }
+	quotas, _, err := s.ClientV3.GetOrganizationQuotas(ccv3.Query{
+		Key:    ccv3.NameFilter,
+		Values: []string{quotaName},
+	})
 	if err != nil {
 		return err
 	}

--- a/cloudfoundry/managers/v3appdeployers/process.go
+++ b/cloudfoundry/managers/v3appdeployers/process.go
@@ -45,11 +45,12 @@ func (a Actor) UpdateApplicationProcess(appDeploy AppDeploy, reverse FallbackFun
 			}
 
 			updatedProcess, _, err := a.client.UpdateProcess(resources.Process{
-				GUID:                process.GUID,
-				Command:             appDeploy.Process.Command,
-				HealthCheckType:     appDeploy.Process.HealthCheckType,
-				HealthCheckEndpoint: appDeploy.Process.HealthCheckEndpoint,
-				HealthCheckTimeout:  appDeploy.Process.HealthCheckTimeout,
+				GUID:                         process.GUID,
+				Command:                      appDeploy.Process.Command,
+				HealthCheckType:              appDeploy.Process.HealthCheckType,
+				HealthCheckEndpoint:          appDeploy.Process.HealthCheckEndpoint,
+				HealthCheckTimeout:           appDeploy.Process.HealthCheckTimeout,
+				HealthCheckInvocationTimeout: appDeploy.Process.HealthCheckInvocationTimeout,
 			})
 			if err != nil {
 				return ctx, err

--- a/cloudfoundry/managers/v3appdeployers/runbinder.go
+++ b/cloudfoundry/managers/v3appdeployers/runbinder.go
@@ -437,16 +437,16 @@ func (r RunBinder) Stop(appDeploy AppDeploy) error {
 }
 
 // Restart simply runs Stop and Start.
-func (r RunBinder) Restart(appDeploy AppDeploy, stageTimeout time.Duration) error {
+func (r RunBinder) Restart(appDeploy AppDeploy) (resources.Application, resources.Process, error) {
 	err := r.Stop(appDeploy)
 	if err != nil {
-		return err
+		return resources.Application{}, resources.Process{}, err
 	}
-	_, _, err = r.Start(appDeploy)
+	app, proc, err := r.Start(appDeploy)
 	if err != nil {
-		return err
+		return resources.Application{}, resources.Process{}, err
 	}
-	return nil
+	return app, proc, nil
 }
 
 func (r RunBinder) processDeployErr(origErr error, appDeploy AppDeploy) error {

--- a/cloudfoundry/managers/v3appdeployers/runbinder.go
+++ b/cloudfoundry/managers/v3appdeployers/runbinder.go
@@ -387,12 +387,14 @@ func (r RunBinder) Start(appDeploy AppDeploy) (resources.Application, resources.
 		return resources.Application{}, resources.Process{}, err
 	}
 
+	// Process update info
 	updatedProcess, _, err := r.client.UpdateProcess(resources.Process{
-		GUID:                scaledProcess.GUID,
-		Command:             appDeploy.Process.Command,
-		HealthCheckType:     appDeploy.Process.HealthCheckType,
-		HealthCheckEndpoint: appDeploy.Process.HealthCheckEndpoint,
-		HealthCheckTimeout:  appDeploy.Process.HealthCheckTimeout,
+		GUID:                         scaledProcess.GUID,
+		Command:                      appDeploy.Process.Command,
+		HealthCheckType:              appDeploy.Process.HealthCheckType,
+		HealthCheckEndpoint:          appDeploy.Process.HealthCheckEndpoint,
+		HealthCheckTimeout:           appDeploy.Process.HealthCheckTimeout,
+		HealthCheckInvocationTimeout: appDeploy.Process.HealthCheckInvocationTimeout,
 	})
 	if err != nil {
 		return resources.Application{}, resources.Process{}, err

--- a/cloudfoundry/managers/v3appdeployers/standard_strategy_v3.go
+++ b/cloudfoundry/managers/v3appdeployers/standard_strategy_v3.go
@@ -180,7 +180,7 @@ func (s Standard) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 				}
 
 				appResp := ctx["app_response"].(AppDeployResponse)
-				app, proc, err := s.runBinder.Start(AppDeploy{
+				app, proc, err := s.runBinder.Restart(AppDeploy{
 					App:          appResp.App,
 					Process:      appDeploy.Process,
 					EnableSSH:    appDeploy.EnableSSH,

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -64,7 +64,7 @@ func resourceApp() *schema.Resource {
 			"instances": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  1,
 			},
 			"memory": &schema.Schema{
 				Type:     schema.TypeInt,

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -223,6 +223,11 @@ func resourceApp() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"health_check_invocation_timeout": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 			"id_bg": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -646,7 +646,7 @@ func resourceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		if d, ok := deployer.(v3appdeployers.CustomRestartStrategy); ok {
 			err = d.Restart(appDeploy)
 		} else {
-			err = session.V3RunBinder.Restart(appDeploy, DefaultStageTimeout)
+			_, _, err = session.V3RunBinder.Restart(appDeploy)
 		}
 		if err != nil {
 			return diag.FromErr(err)

--- a/cloudfoundry/structures_app.go
+++ b/cloudfoundry/structures_app.go
@@ -264,13 +264,14 @@ func ResourceDataToAppDeployV3(d *schema.ResourceData) (v3appdeployers.AppDeploy
 	}
 
 	process := resources.Process{
-		Command:             StringToFilteredString(d.Get("command").(string)),
-		HealthCheckType:     v3Constants.HealthCheckType(d.Get("health_check_type").(string)),
-		HealthCheckEndpoint: d.Get("health_check_http_endpoint").(string),
-		HealthCheckTimeout:  int64(d.Get("health_check_timeout").(int)),
-		Instances:           IntToNullInt(d.Get("instances").(int)),
-		MemoryInMB:          IntToNullUint64Zero(d.Get("memory").(int)),
-		DiskInMB:            IntToNullUint64Zero(d.Get("disk_quota").(int)),
+		Command:                      StringToFilteredString((d.Get("command").(string))),
+		HealthCheckType:              v3Constants.HealthCheckType(d.Get("health_check_type").(string)),
+		HealthCheckEndpoint:          d.Get("health_check_http_endpoint").(string),
+		HealthCheckTimeout:           int64(d.Get("health_check_timeout").(int)),
+		HealthCheckInvocationTimeout: int64(d.Get("health_check_invocation_timeout").(int)),
+		Instances:                    IntToNullInt(d.Get("instances").(int)),
+		MemoryInMB:                   IntToNullUint64Zero(d.Get("memory").(int)),
+		DiskInMB:                     IntToNullUint64Zero(d.Get("disk_quota").(int)),
 	}
 
 	var DockerUsername string
@@ -431,6 +432,7 @@ func ProcessToResourceData(d *schema.ResourceData, proc resources.Process) {
 	_ = d.Set("health_check_type", proc.HealthCheckType)
 	_ = d.Set("health_check_http_endpoint", proc.HealthCheckEndpoint)
 	_ = d.Set("health_check_timeout", proc.HealthCheckTimeout)
+	_ = d.Set("health_check_invocation_timeout", proc.HealthCheckInvocationTimeout)
 
 	// Only set command if present already in tfstate
 	if _, ok := d.GetOk("command"); ok {

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -137,6 +137,7 @@ resource "cloudfoundry_app" "java-spring" {
 * `health_check_http_endpoint` -(Optional, String) The endpoint for the http health check type. The default is '/'.
 * `health_check_type` - (Optional, String) The health check type which can be one of "`port`", "`process`", "`http`". Default is "`port`".
 * `health_check_timeout` - (Optional, Number) The timeout in seconds for the health check.
+* `health_check_invocation_timeout` - (Optional, Number) The timeout in seconds for individual health check requests for "`http`" and "`port`" health checks.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- #438:
  - Add waiting period for copying app's bits
  - Add polling during blue-green rollback code

- #439: 
  - add new attribute `health_check_invocation_timeout` (Optional, Number)

- Move get quota enpoint to v3
- (strategy=standard) restart app after redeployment so that droplet is properly replaced
- Reverse a previous regression: `instances` attribute should have a default value of 1