### PR TITLE
Deploy CF Apps if AppPath is a URL

### DIFF
--- a/cloudfoundry/managers/v3appdeployers/standard_strategy_v3.go
+++ b/cloudfoundry/managers/v3appdeployers/standard_strategy_v3.go
@@ -49,7 +49,7 @@ func (s Standard) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 			return err
 		}
 
-		jobURL, _, err := s.client.DeleteApplication(app.GUID)
+		jobURL, _, _ := s.client.DeleteApplication(app.GUID)
 
 		err = common.PollingWithTimeout(func() (bool, error) {
 			job, _, err := s.client.GetJob(jobURL)

--- a/cloudfoundry/managers/v3appdeployers/standard_strategy_v3.go
+++ b/cloudfoundry/managers/v3appdeployers/standard_strategy_v3.go
@@ -49,7 +49,10 @@ func (s Standard) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 			return err
 		}
 
-		jobURL, _, _ := s.client.DeleteApplication(app.GUID)
+		jobURL, _, err := s.client.DeleteApplication(app.GUID)
+		if err != nil {
+			return err
+		}
 
 		err = common.PollingWithTimeout(func() (bool, error) {
 			job, _, err := s.client.GetJob(jobURL)


### PR DESCRIPTION
 This PR proposes the following changes in the function `CreateAndUploadBitsPackage` to enable deployment of CF Apps with remote `appPath`. 

- If path is a url retrieve the zip file and store in a temp directory.
- Override the path to the location of the zip