### PR TITLE
Document the rolling strategy

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -83,16 +83,18 @@ resource "cloudfoundry_app" "gobis-server" {
 }
 ```
 
-### Application Deployment strategy (Blue-Green deploy)
+### Application Deployment strategy
 
-* `strategy` - (Required) Strategy to use for creating/updating application. Default to `none`
-Following are supported:
+* `strategy` - (Required) Strategy to use for creating/updating application. Defaults to `none`
+Supported options:
   * `none`:
     * Alias: `standard`, `v2`
-    * Description: This is the default strategy, it will restage/create/restart app with interruption
+    * Description: perform restage/create/restart **with** interruption
   * `blue-green`:
     * Alias: `blue-green-v2`
-    * Description: It will restage and create app without interruption and rollback if an error occurred.
+    * Description: perform restage and create app **without** interruption and rollback if an error occurred (using the "venerable" blue-green pattern commonly used with CAPI v2, requires double the overall app memory available in quota)
+  * `rolling`:
+    * Description: perform restage and create app **without** interruption and rollback if an error occurred (using the `rolling` strategy provided in CAPI v3, requires memory for a single app instance available in quota)
 
 ### Service bindings
 


### PR DESCRIPTION
I noticed that [the `rolling` strategy appears to be supported](https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/blob/main/cloudfoundry/managers/v3appdeployers/rolling_strategy.go) and [under test](https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/blob/45d8cd31d6003bfd0e5bfddc510717677c1bc9dd/cloudfoundry/resource_cf_app_test.go#L588) but is undocumented! Can you confirm that's the case, and if so, roll in this PR that updates the docs?

(cc @Thanhphan1147 since [you're the person who wrote that file](https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/commits/main/cloudfoundry/managers/v3appdeployers/rolling_strategy.go)...!)