### PR TITLE
Fix cloudfoundry_app.foo.routes documentation

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -107,12 +107,9 @@ Supported options:
 
 ### Routing
 
-* `routes` - (Optional, Set) The routes to map to the application to control its ingress traffic. Each route mapping is represented by its `route` block which supports fields documented below.
-
-The `route` block supports
-
-* `route` - (Required, String) The route id. Route can be defined using the `cloudfoundry_route` resource
-* `port` - (Number) The port of the application to map the tcp route to.~
+* `routes` - (Optional, block) The routes to map to the application to control its ingress traffic.
+  * `route` - (Required, String) The route id. Route can be defined using the `cloudfoundry_route` resource
+  * `port` - (Number) The port of the application to map the tcp route to.
 
 ~> **NOTE:** in the future, the `route` block will support the `port` attribute illustrated above to allow mapping of tcp routes, and listening on custom or multiple ports.  
 ~> **NOTE:** Route mappings can be controlled from either the `cloudfoundry_app.routes` or the `cloudfoundry_routes.target` attributes. Using both syntaxes will cause conflicts and result in unpredictable behavior.  
@@ -124,10 +121,12 @@ The `route` block supports
 ```hcl
 resource "cloudfoundry_app" "java-spring" {
 # [...]
- routes = [
-    { route = cloudfoundry_route.java-spring.id },
-    { route = cloudfoundry_route.java-spring-2.id }
-  ]
+ routes {
+    route = cloudfoundry_route.java-spring.id
+ }
+ routes {
+    route = cloudfoundry_route.java-spring-2.id
+ }
 }
 ```
 


### PR DESCRIPTION
Contrary to the docs, `routes` is a block, and it has a `route` attribute. If you want to map more than one route, you have to specify multiple `routes` blocks, [as demonstrated here](https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/blob/7f62126d3af1f89fc4d132a2a9644d38361f57af/cloudfoundry/resource_cf_app_test.go#L890-L895).

---
I suggest that, if possible, the `routes` block be able to handle one or more `route` sub-blocks, where there's a `target` attribute in each. This would more closely match what we see over in `cloudfoundry_route`. For example:

```
routes {
  route {
    target = cloudfoundry_route.route1.endpoint
  }
  route {
    target = cloudfoundry_route.route2.endpoint
    port = 61443
  }
}
```


If that is possible, then specifying `route` or `port` attributes at the top level of the `routes` block should be deprecated!