### PR TITLE
New res space asg

### DIFF
--- a/cloudfoundry/provider.go
+++ b/cloudfoundry/provider.go
@@ -124,6 +124,7 @@ func Provider() *schema.Provider {
 			"cloudfoundry_org":                           resourceOrg(),
 			"cloudfoundry_space":                         resourceSpace(),
 			"cloudfoundry_space_users":                   resourceSpaceUsers(),
+			"cloudfoundry_space_asgs":                    resourceSpaceAsgs(),
 			"cloudfoundry_org_users":                     resourceOrgUsers(),
 			"cloudfoundry_service_broker":                resourceServiceBroker(),
 			"cloudfoundry_service_plan_access":           resourceServicePlanAccess(),

--- a/cloudfoundry/resource_cf_space.go
+++ b/cloudfoundry/resource_cf_space.go
@@ -1,8 +1,11 @@
 package cloudfoundry
 
 import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 	"context"
+	"fmt"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -113,6 +116,18 @@ func resourceSpaceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Making the current acting user (used by terrafor itself) space manager and developer in order to avoid
+	// UNAUTHORIZED in subsequent modifications like setting asgs.
+	err = updateSpaceUserByRole(session, constant.SpaceManager, space.GUID, session.Config.User, true)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = updateSpaceUserByRole(session, constant.SpaceDeveloper, space.GUID, session.Config.User, true)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(space.GUID)
 	dg := resourceSpaceUpdate(ctx, d, meta)
 	if dg.HasError() {
@@ -234,15 +249,25 @@ func resourceSpaceUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 	}
 	var err error
+
+	// Hint: Switching implementation from
+	//  	session.ClientV2.DeleteSecurityGroupSpace(asgID, spaceID)
+	// which uses something like
+	// 		/v2/security_groups/:sg_guid/....
+	// to
+	// 		/v2/spaces/:s_guid/asgs/[staging_]security_groups/:asg_guid
+	// the fist variant can only be done with full admin. The latter can be done as space manager
+
 	removeAsgs, addAsgs := getListChanges(d.GetChange("asgs"))
 	for _, asgID := range removeAsgs {
-		_, err = session.ClientV2.DeleteSecurityGroupSpace(asgID, spaceID)
+		err := updateSpaceRemoveRunningAsg(spaceID, asgID, session)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
+
 	for _, asgID := range addAsgs {
-		_, err = session.ClientV2.UpdateSecurityGroupSpace(asgID, spaceID)
+		err := updateSpaceAddRunningAsg(spaceID, asgID, session)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -250,13 +275,14 @@ func resourceSpaceUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	removeStagingAsgs, addStagingAsgs := getListChanges(d.GetChange("staging_asgs"))
 	for _, asgID := range removeStagingAsgs {
-		_, err = session.ClientV2.DeleteSecurityGroupStagingSpace(asgID, spaceID)
+		err := updateSpaceRemoveStagingAsg(spaceID, asgID, session)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
+
 	for _, asgID := range addStagingAsgs {
-		_, err = session.ClientV2.UpdateSecurityGroupStagingSpace(asgID, spaceID)
+		err := updateSpaceAddStagingAsg(spaceID, asgID, session)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -320,4 +346,48 @@ func resourceSpaceDelete(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 	return diag.FromErr(err)
+}
+
+// helper functions
+// These should go to the ClientV2; would someone like to raise a change request?
+func updateSpaceAddRunningAsg(spaceID string, asgID string, session *managers.Session) error {
+	return updateSpaceAsg("PUT", "/v2/spaces/%s/security_groups/%s", spaceID, asgID, session)
+}
+
+func updateSpaceRemoveRunningAsg(spaceID string, asgID string, session *managers.Session) error {
+	return updateSpaceAsg("DELETE", "/v2/spaces/%s/security_groups/%s", spaceID, asgID, session)
+}
+
+func updateSpaceAddStagingAsg(spaceID string, asgID string, session *managers.Session) error {
+	return updateSpaceAsg("PUT", "/v2/spaces/%s/staging_security_groups/%s", spaceID, asgID, session)
+}
+
+func updateSpaceRemoveStagingAsg(spaceID string, asgID string, session *managers.Session) error {
+	return updateSpaceAsg("DELETE", "/v2/spaces/%s/staging_security_groups/%s", spaceID, asgID, session)
+}
+
+func updateSpaceAsg(method string, path string, spaceID string, asgID string, session *managers.Session) error {
+	p := fmt.Sprintf(path, spaceID, asgID)
+
+	req, err := session.RawClient.NewRequest(method, p, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := session.RawClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= 400 {
+		err = ccerror.RawHTTPStatusError{
+			StatusCode: resp.StatusCode,
+		}
+		return err
+	}
+
+	defer func() {
+		resp.Body.Close()
+	}()
+	return nil
 }

--- a/cloudfoundry/resource_cf_space_asgs.go
+++ b/cloudfoundry/resource_cf_space_asgs.go
@@ -1,0 +1,212 @@
+package cloudfoundry
+
+import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/managers"
+)
+
+func resourceSpaceAsgs() *schema.Resource {
+
+	return &schema.Resource{
+
+		CreateContext: resourceSpaceAsgsCreate,
+		ReadContext:   resourceSpaceAsgsRead,
+		UpdateContext: resourceSpaceAsgsUpdate,
+		DeleteContext: resourceSpaceAsgsDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: ImportReadContext(resourceSpaceUsersRead),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"space": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"running_asgs": {
+				Type:       schema.TypeSet,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Computed:   true,
+				Optional:   true,
+				Elem:       &schema.Schema{Type: schema.TypeString},
+				Set:        resourceStringHash,
+			},
+			"staging_asgs": {
+				Type:       schema.TypeSet,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Computed:   true,
+				Optional:   true,
+				Elem:       &schema.Schema{Type: schema.TypeString},
+				Set:        resourceStringHash,
+			},
+		},
+	}
+}
+
+func resourceSpaceAsgsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	return resourceSpaceAsgsUpdate(ctx, d, meta)
+}
+
+func resourceSpaceAsgsRead(c context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	session := meta.(*managers.Session)
+	spaceId := d.Get("space").(string)
+
+	runningAsgs, _, err := session.ClientV2.GetSpaceSecurityGroups(spaceId)
+	if err != nil {
+		return nil
+	}
+	if !IsImportState(d) {
+		finalRunningAsg := intersectSlices(d.Get("running_asgs").(*schema.Set).List(), runningAsgs, func(source, item interface{}) bool {
+			return source.(string) == item.(ccv2.SecurityGroup).GUID
+		})
+		d.Set("running_asgs", schema.NewSet(resourceStringHash, finalRunningAsg))
+	} else {
+		finalRunningAsgs, _ := getInSlice(runningAsgs, func(object interface{}) bool {
+			return !object.(ccv2.SecurityGroup).RunningDefault
+		})
+		d.Set("running_asgs", schema.NewSet(resourceStringHash, objectsToIds(finalRunningAsgs, func(object interface{}) string {
+			return object.(ccv2.SecurityGroup).GUID
+		})))
+	}
+
+	stagingAsgs, _, err := session.ClientV2.GetSpaceStagingSecurityGroups(spaceId)
+	if err != nil {
+		return nil
+	}
+	if !IsImportState(d) {
+		finalStagingAsg := intersectSlices(d.Get("staging_asgs").(*schema.Set).List(), stagingAsgs, func(source, item interface{}) bool {
+			return source.(string) == item.(ccv2.SecurityGroup).GUID
+		})
+		d.Set("staging_asgs", schema.NewSet(resourceStringHash, finalStagingAsg))
+	} else {
+		finalStagingAsgs, _ := getInSlice(stagingAsgs, func(object interface{}) bool {
+			return !object.(ccv2.SecurityGroup).StagingDefault
+		})
+		d.Set("staging_asgs", schema.NewSet(resourceStringHash, objectsToIds(finalStagingAsgs, func(object interface{}) string {
+			return object.(ccv2.SecurityGroup).GUID
+		})))
+	}
+
+	return nil
+}
+
+func resourceSpaceAsgsUpdate(c context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	session := meta.(*managers.Session)
+	spaceID := d.Get("space").(string)
+	_, _, err := session.ClientV2.GetSpace(spaceID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	removeRunningAsgs, addRunningAsgs := getListChanges(d.GetChange("running_asgs"))
+	for _, asgID := range removeRunningAsgs {
+		err := updateSpaceRemoveRunningAsgs(c, spaceID, asgID, session)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	for _, asgID := range addRunningAsgs {
+		err := updateSpaceAddRunningAsgs(c, spaceID, asgID, session)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	removeStagingAsgs, addStagingAsgs := getListChanges(d.GetChange("staging_asgs"))
+	for _, asgID := range removeStagingAsgs {
+		err := updateSpaceRemoveStagingAsgs(c, spaceID, asgID, session)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	for _, asgID := range addStagingAsgs {
+		err := updateSpaceAddStagingAsgs(c, spaceID, asgID, session)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return nil
+}
+
+func resourceSpaceAsgsDelete(c context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	session := meta.(*managers.Session)
+	spaceID := d.Get("space").(string)
+	_, _, err := session.ClientV2.GetSpace(spaceID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	removeRunningAsgs := d.Get("running_asgs").(*schema.Set).List()
+	for _, asgID := range removeRunningAsgs {
+		err := updateSpaceRemoveRunningAsgs(c, spaceID, asgID.(string), session)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	removeStagingAsgs := d.Get("staging_asgs").(*schema.Set).List()
+	for _, asgID := range removeStagingAsgs {
+		err := updateSpaceRemoveStagingAsgs(c, spaceID, asgID.(string), session)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	return nil
+}
+
+// helper functions
+// These should go to the ClientV2; would someone like to raise a change request?
+func updateSpaceAddRunningAsgs(c context.Context, spaceID string, asgID string, session *managers.Session) error {
+	return updateSpaceAsgs(c, "PUT", "/v2/spaces/%s/security_groups/%s", spaceID, asgID, session)
+}
+
+func updateSpaceRemoveRunningAsgs(c context.Context, spaceID string, asgID string, session *managers.Session) error {
+	return updateSpaceAsgs(c, "DELETE", "/v2/spaces/%s/security_groups/%s", spaceID, asgID, session)
+}
+
+func updateSpaceAddStagingAsgs(c context.Context, spaceID string, asgID string, session *managers.Session) error {
+	return updateSpaceAsgs(c, "PUT", "/v2/spaces/%s/staging_security_groups/%s", spaceID, asgID, session)
+}
+
+func updateSpaceRemoveStagingAsgs(c context.Context, spaceID string, asgID string, session *managers.Session) error {
+	return updateSpaceAsgs(c, "DELETE", "/v2/spaces/%s/staging_security_groups/%s", spaceID, asgID, session)
+}
+
+func updateSpaceAsgs(c context.Context, method string, path string, spaceID string, asgID string, session *managers.Session) error {
+	p := fmt.Sprintf(path, spaceID, asgID)
+
+	req, err := session.RawClient.NewRequest(method, p, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := session.RawClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= 400 {
+		err = ccerror.RawHTTPStatusError{
+			StatusCode: resp.StatusCode,
+		}
+	}
+	err = resp.Body.Close()
+	return err
+}

--- a/cloudfoundry/resource_cf_space_asgs_test.go
+++ b/cloudfoundry/resource_cf_space_asgs_test.go
@@ -1,0 +1,114 @@
+package cloudfoundry
+
+import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/managers"
+	"strings"
+	"testing"
+)
+
+const testSetupTfResourceForSpaceAsgs = `
+resource "cloudfoundry_asg" "asg1" {
+	name = "asg-required-at-runtime"
+    rule {
+        protocol = "all"
+        destination = "192.168.100.0/24"
+    }
+}
+resource "cloudfoundry_asg" "asg2" {
+	name = "asg-required-at-staging"
+    rule {
+        protocol = "all"
+        destination = "192.168.101.0/24"
+    }
+}
+resource "cloudfoundry_org" "org1" {
+	name = "organization-one"
+}
+resource "cloudfoundry_space" "space1" {
+    name = "space-two"
+	org = cloudfoundry_org.org1.id
+	quota = ""
+}
+resource "cloudfoundry_space_asgs" "spaceasgs1" {
+    space = cloudfoundry_space.space1.id
+    running_asgs = [ cloudfoundry_asg.asg1.id ]
+    staging_asgs = [ cloudfoundry_asg.asg2.id ]
+}
+`
+
+func TestAccResSpaceAsgs(t *testing.T) {
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:          func() { testAccPreCheck(t) },
+			ProviderFactories: testAccProvidersFactories,
+			CheckDestroy:      testAccCheckSpaceAsgsDestroyed(),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: testSetupTfResourceForSpaceAsgs,
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckSpaceAsgsExists("cloudfoundry_space.space1"),
+					),
+				},
+			},
+		})
+}
+
+func testAccCheckSpaceAsgsExists(resourceTfName string) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		session := testAccProvider.Meta().(*managers.Session)
+
+		rs, ok := s.RootModule().Resources[resourceTfName]
+		if !ok {
+			return fmt.Errorf("Resource '%s' not found in terraform state", resourceTfName)
+		}
+		id := rs.Primary.ID
+
+		runningAsgs, _, err := session.ClientV2.GetSpaceSecurityGroups(id)
+		if err != nil {
+			return fmt.Errorf("Error while trying to load asgs for space %s: %s.", id, err.Error())
+		}
+
+		finalRunningAsgs, _ := getInSlice(runningAsgs, func(object interface{}) bool {
+			return !object.(ccv2.SecurityGroup).RunningDefault && object.(ccv2.SecurityGroup).Name == "asg-required-at-runtime"
+		})
+
+		if len(finalRunningAsgs) != 1 {
+			return fmt.Errorf("Expected one running asg named 'asg-required-at-runtime' but found '%s'.", getNamesOfSecorityGroups(finalRunningAsgs))
+		}
+
+		stagingAsgs, _, err := session.ClientV2.GetSpaceStagingSecurityGroups(id)
+
+		finalStagingAsgs, _ := getInSlice(stagingAsgs, func(object interface{}) bool {
+			return !object.(ccv2.SecurityGroup).StagingDefault && object.(ccv2.SecurityGroup).Name == "asg-required-at-staging"
+		})
+
+		if len(finalStagingAsgs) != 1 {
+			return fmt.Errorf("Expected one staging asg named 'asg-required-at-staging' but found '%s'.", getNamesOfSecorityGroups(finalStagingAsgs))
+		}
+
+		return nil
+	}
+}
+
+func getNamesOfSecorityGroups(objs []interface{}) string {
+	var names []string
+	for _, o := range objs {
+		names = append(names, o.(ccv2.SecurityGroup).Name)
+	}
+	return strings.Join(names, ",")
+}
+
+func testAccCheckSpaceAsgsDestroyed() resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		// it does not make much sense to test this because the relation space - asg is not an object itself
+		return nil
+	}
+}


### PR DESCRIPTION
Reverted the changes of the first fix which added the acting terraform user as space manager to a newly created space

Instead introduced a new resource named space_asgs which enables the sequence create space, assign space users, assign asgs