### PR TITLE
docs: Import example was wrong

### DIFF
--- a/docs/resources/service_instance.md
+++ b/docs/resources/service_instance.md
@@ -49,7 +49,7 @@ The following attributes are exported:
 An existing Service Instance can be imported using its guid, e.g.
 
 ```bash
-terraform import cloudfoundry_service.redis a-guid
+terraform import cloudfoundry_service_instance.redis a-guid
 ```
 
 ### Timeouts


### PR DESCRIPTION
`$ terraform import cloudfoundry_service.redis a-guid`
Error: resource address "terraform import cloudfoundry_service.redis" does not exist in the configuration.

`$ terraform import cloudfoundry_service_instance.redis a-guid`
Import successful!