### PR TITLE
Deprecate recursive_delete for service instances

### DIFF
--- a/cloudfoundry/resource_cf_service_instance.go
+++ b/cloudfoundry/resource_cf_service_instance.go
@@ -85,7 +85,7 @@ func resourceServiceInstance() *schema.Resource {
 				Type:       schema.TypeBool,
 				Optional:   true,
 				Deprecated: "Since CF API v3, recursive delete is always done on the cloudcontroller side. This will be removed in future releases",
-				// Supressing all diffs on this attribute
+				// Suppressing all diffs on this attribute
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 					return true
 				},

--- a/cloudfoundry/resource_cf_service_instance.go
+++ b/cloudfoundry/resource_cf_service_instance.go
@@ -82,9 +82,13 @@ func resourceServiceInstance() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"recursive_delete": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Deprecated: "Since CF API v3, recursive delete is always done on the cloudcontroller side. This will be removed in future releases",
+				// Supressing all diffs on this attribute
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 		},
 		CustomizeDiff: customdiff.All(

--- a/docs/resources/service_instance.md
+++ b/docs/resources/service_instance.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `space` - (Required, String) The ID of the [space](/docs/providers/cloudfoundry/r/space.html)
 * `json_params` - (Optional, String) Json string of arbitrary parameters. Some services support providing additional configuration parameters within the provision request. By default, no params are provided.
 * `tags` - (Optional, List) List of instance tags. Some services provide a list of tags that Cloud Foundry delivers in [VCAP_SERVICES Env variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES). By default, no tags are assigned.
-* `recursive_delete` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will delete any service bindings, service keys, and route mappings associated with the service instance. This flag should only be set when such dependent resources were provisioned outside of terraform, and need removal to enable deletion of the associated service instance.
+* `recursive_delete` - DEPRECATED, Since CF API v3, recursive delete is done automatically by the cloudcontroller. This will be removed in future releases.
 * `replace_on_params_change` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will replace the resource on any params change. This is useful if the service does not support parameter updates.
 * `replace_on_service_plan_change` - (Optional, Bool) Default: `false`. If set `true`, Cloud Foundry will replace the resource on any service plan changes. Some brokered services do not support plan changes and this allows the provider to handle those cases.
 


### PR DESCRIPTION
ccv2 required adding this as parameter to enable deletions of binding and associated routes. But ccv3 does this automatically and does not allow users to disable it. This attribute is now no longer in use and should be removed.