### PR TITLE
Clarify RetrieveZip error

### DIFF
--- a/cloudfoundry/managers/bits/bitsmanager.go
+++ b/cloudfoundry/managers/bits/bitsmanager.go
@@ -340,7 +340,7 @@ func (m BitsManager) RetrieveZip(path string) (ZipFile, error) {
 		}
 		fileSize := resp.ContentLength
 		if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-			return ZipFile{}, fmt.Errorf(resp.Status)
+			return ZipFile{}, fmt.Errorf("Failed to download file %s (%s)", path, strings.Trim(resp.Status, " "))
 		}
 		_, params, err := mime.ParseMediaType(resp.Header.Get("Content-Disposition"))
 		if err == nil {


### PR DESCRIPTION
The RetrieveZip failure was very cryptic and it took me a long time to understand what the failure really meant. This change add a few more explanation to the error message.

Before:
```
    resource_cf_app_test.go:1543: Step 1/3 error: Error running apply: exit status 1
        
        Error: 404 
        
          with cf_app.app_1,
          on terraform_plugin_test.tf line 18, in resource "cf_app" "app_1":
          18: resource "cf_app" "app_1" {
```

After:
```
    resource_cf_app_test.go:1543: Step 1/3 error: Error running apply: exit status 1

        Error: Failed to download file https://int.rexxxxxxxapp.0.1-bundle.tar.gz (404)

          with cf_app.app_1,
          on terraform_plugin_test.tf line 18, in resource "cf_app" "app_1":
          18: resource "cf_app" "app_1" {
```