### PR TITLE
adding possibility to disallow recursive deletion for orgs, spaces

### DIFF
--- a/cloudfoundry/managers/config.go
+++ b/cloudfoundry/managers/config.go
@@ -2,18 +2,20 @@ package managers
 
 // Config -
 type Config struct {
-	Endpoint                  string
-	User                      string
-	Password                  string
-	SSOPasscode               string
-	CFClientID                string
-	CFClientSecret            string
-	UaaClientID               string
-	UaaClientSecret           string
-	SkipSslValidation         bool
-	AppLogsMax                int
-	PurgeWhenDelete           bool
-	DefaultQuotaName          string
-	StoreTokensPath           string
-	ForceNotFailBrokerCatalog bool
+	Endpoint                    string
+	User                        string
+	Password                    string
+	SSOPasscode                 string
+	CFClientID                  string
+	CFClientSecret              string
+	UaaClientID                 string
+	UaaClientSecret             string
+	SkipSslValidation           bool
+	AppLogsMax                  int
+	PurgeWhenDelete             bool
+	DefaultQuotaName            string
+	StoreTokensPath             string
+	ForceNotFailBrokerCatalog   bool
+	AllowRecursiveOrgDeletion   bool
+	AllowRecursiveSpaceDeletion bool
 }

--- a/cloudfoundry/provider.go
+++ b/cloudfoundry/provider.go
@@ -89,6 +89,18 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("CF_FORCE_BROKER_NOT_FAIL_CATALOG", false),
 				Description: "Set to true to not trigger fail on catalog on service broker",
 			},
+			"allow_recursive_org_deletion": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CF_ALLOW_RECURSIVE_ORG_DELETION", true),
+				Description: "Set to false to disallow recursive deletion of organization",
+			},
+			"allow_recursive_space_deletion": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CF_ALLOW_RECURSIVE_SPACE_DELETION", true),
+				Description: "Set to false to disallow recursive deletion of space",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -146,19 +158,21 @@ func Provider() *schema.Provider {
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	c := managers.Config{
-		Endpoint:                  strings.TrimSuffix(d.Get("api_url").(string), "/"),
-		User:                      d.Get("user").(string),
-		Password:                  d.Get("password").(string),
-		SSOPasscode:               d.Get("sso_passcode").(string),
-		CFClientID:                d.Get("cf_client_id").(string),
-		CFClientSecret:            d.Get("cf_client_secret").(string),
-		UaaClientID:               d.Get("uaa_client_id").(string),
-		UaaClientSecret:           d.Get("uaa_client_secret").(string),
-		SkipSslValidation:         d.Get("skip_ssl_validation").(bool),
-		AppLogsMax:                d.Get("app_logs_max").(int),
-		DefaultQuotaName:          d.Get("default_quota_name").(string),
-		StoreTokensPath:           d.Get("store_tokens_path").(string),
-		ForceNotFailBrokerCatalog: d.Get("force_broker_not_fail_when_catalog_not_accessible").(bool),
+		Endpoint:                    strings.TrimSuffix(d.Get("api_url").(string), "/"),
+		User:                        d.Get("user").(string),
+		Password:                    d.Get("password").(string),
+		SSOPasscode:                 d.Get("sso_passcode").(string),
+		CFClientID:                  d.Get("cf_client_id").(string),
+		CFClientSecret:              d.Get("cf_client_secret").(string),
+		UaaClientID:                 d.Get("uaa_client_id").(string),
+		UaaClientSecret:             d.Get("uaa_client_secret").(string),
+		SkipSslValidation:           d.Get("skip_ssl_validation").(bool),
+		AppLogsMax:                  d.Get("app_logs_max").(int),
+		DefaultQuotaName:            d.Get("default_quota_name").(string),
+		StoreTokensPath:             d.Get("store_tokens_path").(string),
+		ForceNotFailBrokerCatalog:   d.Get("force_broker_not_fail_when_catalog_not_accessible").(bool),
+		AllowRecursiveOrgDeletion:   d.Get("allow_recursive_org_deletion").(bool),
+		AllowRecursiveSpaceDeletion: d.Get("allow_recursive_space_deletion").(bool),
 	}
 	session, err := managers.NewSession(c)
 	return session, diag.FromErr(err)

--- a/cloudfoundry/resource_cf_org.go
+++ b/cloudfoundry/resource_cf_org.go
@@ -175,6 +175,13 @@ func resourceOrgDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	id := d.Id()
 	spaces, _, err := client.GetSpaces(ccv2.FilterByOrg(id))
 
+	// Check if we are allowed to recursively delete spaces
+	if !session.Config.AllowRecursiveOrgDeletion {
+		if len(spaces) > 0 {
+			return diag.Errorf("Organization %s has %d spaces. Please delete them first.", id, len(spaces))
+		}
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,3 +82,8 @@ The following arguments are supported:
   
 * `force_broker_not_fail_when_catalog_not_accessible` (Optional) Set to true to enforce `fail_when_catalog_not_accessible` to `true` to all broker for avoiding being
   stuck if broker has been deleted for example. This can also be specified with the `CF_FORCE_BROKER_NOT_FAIL_CATALOG` shell environment variable.
+
+* `allow_recursive_org_deletion` (Optional, Default: `true`) Set to false to disallow recursive deletion of ressources inside concerned org. This can also be specified with the `CF_ALLOW_RECURSIVE_ORG_DELETION` shell environment variable.
+
+* `allow_recursive_space_deletion` (Optional, Default: `true`) Set to false to disallow recursive deletion of ressources inside concerned space. This can also be specified with the `CF_ALLOW_RECURSIVE_SPACE_DELETION` shell environment variable.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,4 +86,3 @@ The following arguments are supported:
 * `allow_recursive_org_deletion` (Optional, Default: `true`) Set to false to disallow recursive deletion of ressources inside concerned org. This can also be specified with the `CF_ALLOW_RECURSIVE_ORG_DELETION` shell environment variable.
 
 * `allow_recursive_space_deletion` (Optional, Default: `true`) Set to false to disallow recursive deletion of ressources inside concerned space. This can also be specified with the `CF_ALLOW_RECURSIVE_SPACE_DELETION` shell environment variable.
-


### PR DESCRIPTION
linked to issue #529 
recursive deletion :
  - for orgs : check if there is no spaces left
  - for spaces : check if there is no apps, routes or service instances left

update doc for disallowing recursive deletion for orgs, spaces and service brokers

remove possibility to disallow recursive deletion for service brokers because deleting this ressource isn't recursive

update delete space api v3