### PR TITLE
feat: support login with custom origin

### DIFF
--- a/cloudfoundry/managers/config.go
+++ b/cloudfoundry/managers/config.go
@@ -3,6 +3,7 @@ package managers
 // Config -
 type Config struct {
 	Endpoint                  string
+	Origin                    string
 	User                      string
 	Password                  string
 	SSOPasscode               string

--- a/cloudfoundry/managers/session.go
+++ b/cloudfoundry/managers/session.go
@@ -230,20 +230,20 @@ func (s *Session) init(config *configv3.Config, configUaa *configv3.Config, conf
 		// try connecting with SSO passcode to retrieve access token and refresh token
 		accessToken, refreshToken, err = uaaClient.Authenticate(map[string]string{
 			"passcode": configSess.SSOPasscode,
-		}, "", constant.GrantTypePassword)
+		}, configSess.Origin, constant.GrantTypePassword)
 		errType = "SSO passcode"
 	} else if config.CFUsername() != "" {
 		// try connecting with pair given on uaa to retrieve access token and refresh token
 		accessToken, refreshToken, err = uaaClient.Authenticate(map[string]string{
 			"username": config.CFUsername(),
 			"password": config.CFPassword(),
-		}, "", constant.GrantTypePassword)
+		}, configSess.Origin, constant.GrantTypePassword)
 		errType = "username/password"
 	} else if config.UAAOAuthClient() != "cf" {
 		accessToken, refreshToken, err = uaaClient.Authenticate(map[string]string{
 			"client_id":     config.UAAOAuthClient(),
 			"client_secret": config.UAAOAuthClientSecret(),
-		}, "", constant.GrantTypeClientCredentials)
+		}, configSess.Origin, constant.GrantTypeClientCredentials)
 		errType = "client_id/client_secret"
 	}
 	if err != nil {
@@ -295,7 +295,7 @@ func (s *Session) init(config *configv3.Config, configUaa *configv3.Config, conf
 			accessTokenSess, refreshTokenSess, err = uaaClientSess.Authenticate(map[string]string{
 				"client_id":     configUaa.UAAOAuthClient(),
 				"client_secret": configUaa.UAAOAuthClientSecret(),
-			}, "", constant.GrantTypeClientCredentials)
+			}, configSess.Origin, constant.GrantTypeClientCredentials)
 		}
 
 		if err != nil {

--- a/cloudfoundry/provider.go
+++ b/cloudfoundry/provider.go
@@ -19,6 +19,11 @@ func Provider() *schema.Provider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CF_API_URL", ""),
 			},
+			"origin": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CF_ORIGIN", ""),
+			},
 			"user": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -147,6 +152,7 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	c := managers.Config{
 		Endpoint:                  strings.TrimSuffix(d.Get("api_url").(string), "/"),
+		Origin:                    d.Get("origin").(string),
 		User:                      d.Get("user").(string),
 		Password:                  d.Get("password").(string),
 		SSOPasscode:               d.Get("sso_passcode").(string),

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,9 @@ The following arguments are supported:
 * `api_url` - (Required) API endpoint (e.g. [https://api.local.pcfdev.io](https://api.local.pcfdev.io)). This can also be specified
   with the `CF_API_URL` shell environment variable.
 
+* `origin` - (Optional) Indicates the identity provider to be used for login. This can also be specified
+  with the `CF_ORIGIN` shell environment variable.
+
 * `user` - (Optional) Cloud Foundry user. Defaults to "admin". This can also be specified
   with the `CF_USER` shell environment variable. Unless mentionned explicitly in a resource, CF admin permissions are not required.
 


### PR DESCRIPTION
The CF CLI supports authentication with custom IDPs, but for whatever reasons this is not yet supported by the tf provider. This PR adds a new attribute `origin` to the provider configuration to address this issue.

```hcl
provider "cloudfoundry" {
   origin = "my-idp-platform"
   user   = "john.doe@test.com"
}
```