### PR TITLE
bump community cloudfoundry-cli to v6.44.1-0.20240130060226-cda5ed8e89a5+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 toolchain go1.21.6
 
-replace code.cloudfoundry.org/cli => github.com/cloudfoundry-community/cloudfoundry-cli v6.44.1-0.20230105092217-5241fbe25735+incompatible
+replace code.cloudfoundry.org/cli => github.com/cloudfoundry-community/cloudfoundry-cli v6.44.1-0.20240130060226-cda5ed8e89a5+incompatible
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20231017140541-3b893ed0421b // indirect

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/cloudfoundry-community/cloudfoundry-cli v6.44.1-0.20230105092217-5241fbe25735+incompatible h1:nszsvfYZFXPgDOtUrg8WNpZLfioohSc7PeERE4o4pZE=
-github.com/cloudfoundry-community/cloudfoundry-cli v6.44.1-0.20230105092217-5241fbe25735+incompatible/go.mod h1:DigEBZwaNy/7RSrQpKuMeADXY5tFaWaieQX+UM8+0fA=
+github.com/cloudfoundry-community/cloudfoundry-cli v6.44.1-0.20240130060226-cda5ed8e89a5+incompatible h1:/j/6U9gjS71cThZtQLcZiQ0RpVzNs9uloln9+KlaWDc=
+github.com/cloudfoundry-community/cloudfoundry-cli v6.44.1-0.20240130060226-cda5ed8e89a5+incompatible/go.mod h1:DigEBZwaNy/7RSrQpKuMeADXY5tFaWaieQX+UM8+0fA=
 github.com/cloudfoundry/bosh-cli v6.4.1+incompatible h1:n5/+NIF9QxvGINOrjh6DmO+GTen78MoCj5+LU9L8bR4=
 github.com/cloudfoundry/bosh-cli v6.4.1+incompatible/go.mod h1:rzIB+e1sn7wQL/TJ54bl/FemPKRhXby5BIMS3tLuWFM=
 github.com/cloudfoundry/bosh-utils v0.0.427 h1:SMy+jCPC5osnURz5vsOdRSTLz3NSnjVIAzrc93WweM8=


### PR DESCRIPTION
This PR bump community's cloudfoundry-cli to v6.44.1-0.20240130060226-cda5ed8e89a5+incompatible.
This version of cloudfoundry-cli fixes bugs occuring when using some specifics ressources such as isolation segments.

(See [ccv3.Client : replace usages of newHTTPRequet when possible #6](https://github.com/cloudfoundry-community/cloudfoundry-cli/pull/6))

This PR fixes issue #449.

