### PR TITLE
Added create and delete timeouts for cloudfoundry_service_key resource

### DIFF
--- a/cloudfoundry/resource_cf_service_key.go
+++ b/cloudfoundry/resource_cf_service_key.go
@@ -31,6 +31,11 @@ func resourceServiceKey() *schema.Resource {
 			StateContext: ImportReadContext(resourceServiceKeyRead),
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Second),
+			Delete: schema.DefaultTimeout(60 * time.Second),
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{
@@ -146,7 +151,7 @@ func resourceServiceKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 		// Last operation initial or inprogress or job not completed, continue polling
 		return false, nil
-	}, 5*time.Second, 60*time.Second)
+	}, 5*time.Second, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -240,6 +245,6 @@ func resourceServiceKeyDelete(ctx context.Context, d *schema.ResourceData, meta 
 		}
 		// Last operation initial or inprogress or job not completed, continue polling
 		return false, nil
-	}, 5*time.Second, 60*time.Second)
+	}, 5*time.Second, d.Timeout(schema.TimeoutDelete))
 	return diag.FromErr(err)
 }

--- a/cloudfoundry/resource_cf_service_key.go
+++ b/cloudfoundry/resource_cf_service_key.go
@@ -146,7 +146,7 @@ func resourceServiceKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 		// Last operation initial or inprogress or job not completed, continue polling
 		return false, nil
-	}, 5*time.Second, 300*time.Second)
+	}, 5*time.Second, 60*time.Second)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/cloudfoundry/resource_cf_service_key.go
+++ b/cloudfoundry/resource_cf_service_key.go
@@ -146,7 +146,7 @@ func resourceServiceKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 		// Last operation initial or inprogress or job not completed, continue polling
 		return false, nil
-	}, 5*time.Second, 60*time.Second)
+	}, 5*time.Second, 300*time.Second)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/cloudfoundry/resource_cf_service_key_test.go
+++ b/cloudfoundry/resource_cf_service_key_test.go
@@ -28,6 +28,11 @@ resource "cloudfoundry_service_key" "test-service-instance-key" {
 		"key1" = "aaaa"
 		"key2" = "bbbb"
 	}
+
+	timeouts {
+		create = "3m"
+		delete = "2m"
+	}
 }
 `
 

--- a/docs/resources/service_key.md
+++ b/docs/resources/service_key.md
@@ -54,3 +54,11 @@ An existing Service Key can be imported using its guid , e.g.
 ```bash
 terraform import cloudfoundry_service_key.redis1-key1 a-guid
 ```
+
+### Timeouts
+
+`cloudfoundry_service_key` provides the following
+[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Default `60 seconds`) Used for Creating Instance.
+* `delete` - (Default `60 seconds`) Used for Destroying Instance.


### PR DESCRIPTION
The defaults are not changed from the initial implementation (60 seconds for both).

Generally, service key creation should not take more than a minute, but, if the service needs to execute complex operations, as, part of the key creation, this can take longer.