### PR TITLE
Fix minor typo in resource name

### DIFF
--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -33,7 +33,7 @@ resource "cloudfoundry_domain" "private" {
 }
 ```
 
-~> **NOTE:** To control sharing of a private domain, use the [cloudfoundry_private_domain](private_domain_access.html) resource.
+~> **NOTE:** To control sharing of a private domain, use the [cloudfoundry_private_domain_access](private_domain_access.html) resource.
 
 ## Argument Reference
 


### PR DESCRIPTION
Noticed that a reference to `cloudfoundry_private_domain_access` was still called `cloudfoundry_private_domain`.