### PR TITLE
Fix app deletion in case of unsuccessful app creation

### DIFF
--- a/cloudfoundry/managers/v3appdeployers/standard_strategy_v3.go
+++ b/cloudfoundry/managers/v3appdeployers/standard_strategy_v3.go
@@ -6,7 +6,6 @@ import (
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
-	constantV3 "code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 
 	"code.cloudfoundry.org/cli/resources"
 	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/common"
@@ -49,32 +48,7 @@ func (s Standard) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 			return err
 		}
 
-		jobURL, _, err := s.client.DeleteApplication(app.GUID)
-		if err != nil {
-			return err
-		}
-
-		err = common.PollingWithTimeout(func() (bool, error) {
-			job, _, err := s.client.GetJob(jobURL)
-			if err != nil {
-				return true, err
-			}
-
-			// Stop polling and return error if job failed
-			if job.State == constantV3.JobFailed {
-				return true, fmt.Errorf(
-					"Operation failed, reason: %+v",
-					job.Errors(),
-				)
-			}
-
-			if job.State == constantV3.JobComplete {
-				return true, nil
-			}
-
-			return false, nil
-		}, 5*time.Second, 1*time.Minute)
-		return err
+		return SafeAppDeletion(*s.client, app.GUID, 5)
 	}
 	actions := Actions{
 		{


### PR DESCRIPTION
Hello,
When creating an application fails, the failed application stays in stopped state and is not deleted.
We encountered this problem while we deploy an application with a binding that took too long to create.
The proposal is to use the SafeAppDeletion in this case.
we found this problem similar to this issue: https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/issues/546