### PR TITLE
blue green strategy: add time before deleting venerable app

### DIFF
--- a/cloudfoundry/managers/v3appdeployers/appsdef.go
+++ b/cloudfoundry/managers/v3appdeployers/appsdef.go
@@ -8,18 +8,19 @@ import (
 )
 
 type AppDeploy struct {
-	App             resources.Application
-	EnableSSH       types.NullBool
-	AppPackage      resources.Package
-	Process         resources.Process
-	Mappings        []resources.Route
-	ServiceBindings []resources.ServiceCredentialBinding
-	EnvVars         map[string]interface{}
-	Path            string
-	BindTimeout     time.Duration
-	StageTimeout    time.Duration
-	StartTimeout    time.Duration
-	Ports           []int
+	App                          resources.Application
+	EnableSSH                    types.NullBool
+	AppPackage                   resources.Package
+	Process                      resources.Process
+	Mappings                     []resources.Route
+	ServiceBindings              []resources.ServiceCredentialBinding
+	EnvVars                      map[string]interface{}
+	Path                         string
+	BindTimeout                  time.Duration
+	StageTimeout                 time.Duration
+	StartTimeout                 time.Duration
+	BlueGreenPostStartupWaitTime time.Duration
+	Ports                        []int
 }
 
 func (a AppDeploy) IsDockerImage() bool {

--- a/cloudfoundry/managers/v3appdeployers/bluegreen_strategy_v3.go
+++ b/cloudfoundry/managers/v3appdeployers/bluegreen_strategy_v3.go
@@ -100,6 +100,12 @@ func (s BlueGreen) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 		},
 		{
 			Forward: func(ctx Context) (Context, error) {
+				time.Sleep(appDeploy.BlueGreenPostStartupWaitTime)
+				return ctx, nil
+			},
+		},
+		{
+			Forward: func(ctx Context) (Context, error) {
 				// Ask CF to stop application (desired state)
 				_, _, err := s.client.UpdateApplicationStop(appDeploy.App.GUID)
 				return ctx, err
@@ -288,6 +294,12 @@ func (s BlueGreen) Restage(appDeploy AppDeploy) (AppDeployResponse, error) {
 				if err == nil {
 					_ = metadataUpdate(appResp.App.GUID, "apps", s.rawClient, metadata)
 				}
+				return ctx, nil
+			},
+		},
+		{
+			Forward: func(ctx Context) (Context, error) {
+				time.Sleep(appDeploy.BlueGreenPostStartupWaitTime)
 				return ctx, nil
 			},
 		},

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -24,10 +24,11 @@ import (
 // schema.BasicMapReader
 // DefaultAppTimeout - Timeout (in seconds) when pushing apps to CF
 const (
-	DefaultAppTimeout   = 60
-	DefaultBindTimeout  = 5 * time.Minute
-	DefaultStageTimeout = 15 * time.Minute
-	DefaultAppPort      = 8080
+	DefaultAppTimeout                   = 60
+	DefaultBindTimeout                  = 5 * time.Minute
+	DefaultStageTimeout                 = 15 * time.Minute
+	DefaultAppPort                      = 8080
+	DefaultBlueGreenPostStartupWaitTime = 10
 )
 
 func resourceApp() *schema.Resource {
@@ -120,6 +121,11 @@ func resourceApp() *schema.Resource {
 				Default:      "none",
 				Description:  "Deployment strategy, default to none but accept blue-green strategy",
 				ValidateFunc: validateV3Strategy,
+			},
+			"bg_post_startup_wait_time": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  DefaultBlueGreenPostStartupWaitTime,
 			},
 			"path": &schema.Schema{
 				Type:          schema.TypeString,

--- a/cloudfoundry/structures_app.go
+++ b/cloudfoundry/structures_app.go
@@ -328,18 +328,19 @@ func ResourceDataToAppDeployV3(d *schema.ResourceData) (v3appdeployers.AppDeploy
 	}
 
 	appDeploy := v3appdeployers.AppDeploy{
-		App:             app,
-		AppPackage:      appPackage,
-		Process:         process,
-		EnableSSH:       enableSSH,
-		Mappings:        mappings,
-		ServiceBindings: bindings,
-		Path:            d.Get("path").(string),
-		BindTimeout:     DefaultBindTimeout,
-		StageTimeout:    DefaultStageTimeout,
-		StartTimeout:    time.Duration(d.Get("timeout").(int)) * time.Second,
-		EnvVars:         envVars,
-		Ports:           ports,
+		App:                          app,
+		AppPackage:                   appPackage,
+		Process:                      process,
+		EnableSSH:                    enableSSH,
+		Mappings:                     mappings,
+		ServiceBindings:              bindings,
+		Path:                         d.Get("path").(string),
+		BindTimeout:                  DefaultBindTimeout,
+		StageTimeout:                 DefaultStageTimeout,
+		StartTimeout:                 time.Duration(d.Get("timeout").(int)) * time.Second,
+		BlueGreenPostStartupWaitTime: time.Duration(d.Get("bg_post_startup_wait_time").(int)) * time.Second,
+		EnvVars:                      envVars,
+		Ports:                        ports,
 	}
 
 	return appDeploy, nil


### PR DESCRIPTION
Some apps can take a few moments to be fully up even after Cloudfoundry declared them "started" : database schema migrations, establishing connections to clients...

We had some reports of downtime because the venerable app was deleted when the new app was not fully "started" (even if Cloudfoundry was showing it started : it's not a bug in Cloudfoundry more like a practical issue on our side)