### PR TITLE
blue green strategy: wait for app to be really stopped workaround

### DIFF
--- a/cloudfoundry/managers/v3appdeployers/appsdef.go
+++ b/cloudfoundry/managers/v3appdeployers/appsdef.go
@@ -8,18 +8,19 @@ import (
 )
 
 type AppDeploy struct {
-	App             resources.Application
-	EnableSSH       types.NullBool
-	AppPackage      resources.Package
-	Process         resources.Process
-	Mappings        []resources.Route
-	ServiceBindings []resources.ServiceCredentialBinding
-	EnvVars         map[string]interface{}
-	Path            string
-	BindTimeout     time.Duration
-	StageTimeout    time.Duration
-	StartTimeout    time.Duration
-	Ports           []int
+	App                                             resources.Application
+	EnableSSH                                       types.NullBool
+	AppPackage                                      resources.Package
+	Process                                         resources.Process
+	Mappings                                        []resources.Route
+	ServiceBindings                                 []resources.ServiceCredentialBinding
+	EnvVars                                         map[string]interface{}
+	Path                                            string
+	BindTimeout                                     time.Duration
+	StageTimeout                                    time.Duration
+	StartTimeout                                    time.Duration
+	EnableWaitMaximumGracefulShutdownTimeWorkaround bool
+	Ports                                           []int
 }
 
 func (a AppDeploy) IsDockerImage() bool {

--- a/cloudfoundry/managers/v3appdeployers/bluegreen_strategy_v3.go
+++ b/cloudfoundry/managers/v3appdeployers/bluegreen_strategy_v3.go
@@ -103,11 +103,13 @@ func (s BlueGreen) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 				// Ask CF to stop application (desired state)
 				_, _, err := s.client.UpdateApplicationStop(appDeploy.App.GUID)
 
-				// WORKAROUND of https://github.com/cloudfoundry/cloud_controller_ng/issues/3780
-				// Since CF is showing DOWN on processed that are not stopped,
-				// give them 20 seconds of grace period to shutdown properly before deleting them
-				// (SAP BTP Cloudfoundry implementation actually gives 60 seconds for apps to shutdown)
-				time.Sleep(stopAppTimeout * time.Second)
+				if appDeploy.EnableWaitMaximumGracefulShutdownTimeWorkaround {
+					// WORKAROUND of https://github.com/cloudfoundry/cloud_controller_ng/issues/3780
+					// Since CF is showing DOWN on processed that are not stopped,
+					// give them 20 seconds of grace period to shutdown properly before deleting them
+					// (SAP BTP Cloudfoundry implementation actually gives 60 seconds for apps to shutdown)
+					time.Sleep(stopAppTimeout * time.Second)
+				}
 
 				return ctx, err
 			},

--- a/cloudfoundry/managers/v3appdeployers/bluegreen_strategy_v3.go
+++ b/cloudfoundry/managers/v3appdeployers/bluegreen_strategy_v3.go
@@ -102,6 +102,13 @@ func (s BlueGreen) Deploy(appDeploy AppDeploy) (AppDeployResponse, error) {
 			Forward: func(ctx Context) (Context, error) {
 				// Ask CF to stop application (desired state)
 				_, _, err := s.client.UpdateApplicationStop(appDeploy.App.GUID)
+
+				// WORKAROUND of https://github.com/cloudfoundry/cloud_controller_ng/issues/3780
+				// Since CF is showing DOWN on processed that are not stopped,
+				// give them 20 seconds of grace period to shutdown properly before deleting them
+				// (SAP BTP Cloudfoundry implementation actually gives 60 seconds for apps to shutdown)
+				time.Sleep(stopAppTimeout * time.Second)
+
 				return ctx, err
 			},
 		},

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -104,6 +104,11 @@ func resourceApp() *schema.Resource {
 				Optional:   true,
 				Computed:   true,
 			},
+			"enable_wait_maximum_graceful_shutdown_time_workaround": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"timeout": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,

--- a/cloudfoundry/structures_app.go
+++ b/cloudfoundry/structures_app.go
@@ -339,7 +339,8 @@ func ResourceDataToAppDeployV3(d *schema.ResourceData) (v3appdeployers.AppDeploy
 		StageTimeout:    DefaultStageTimeout,
 		StartTimeout:    time.Duration(d.Get("timeout").(int)) * time.Second,
 		EnvVars:         envVars,
-		Ports:           ports,
+		EnableWaitMaximumGracefulShutdownTimeWorkaround: d.Get("enable_wait_maximum_graceful_shutdown_time_workaround").(bool),
+		Ports: ports,
 	}
 
 	return appDeploy, nil


### PR DESCRIPTION
As described here: https://github.com/cloudfoundry/cloud_controller_ng/issues/3780, in releases anteriors to [1.184.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.184.0) of the Cloudfoundry controller, when we instruct Cloudfoundry to stop an app, it immediately reports the state "STOPPED" for the app and shows CPU, memory, etc... metrics to be 0.

In this provider once the app is reported to be "STOPPED" we delete it, so its bindings are deleted and even if the app has still access to the bindings in their env, some services invalidate binding credentials as soon as they are deleted. This causes the app to not be able to finish its work properly.

This workaround is to allow the maximum graceful shutdown time for the apps since we can't trust the "STOPPED" status.

Since it has been fixed since in Cloudfoundry, the workaround is enabled with an option, so people that already have the fix can just ignore it.